### PR TITLE
docs: update CLAUDE.md with test count, CI/CD, and security invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Boruna: a complete, deterministic, capability-safe programming language and fram
 # Build everything
 cargo build --workspace
 
-# Run all tests (440+ tests across 9 crates)
+# Run all tests (501+ tests across 9 crates)
 cargo test --workspace
 
 # Run tests for a single crate
@@ -45,7 +45,20 @@ cargo run --bin boruna -- lang repair file.ax
 # Templates
 cargo run --bin boruna -- template list
 cargo run --bin boruna -- template apply crud-admin --args "entity_name=products,fields=name|price" --validate
+
+# CI/CD — runs on every push/PR (GitHub Actions)
+# Clippy (zero warnings policy)
+cargo clippy --workspace -- -D warnings
+
+# Format check
+cargo fmt --all -- --check
 ```
+
+## Repository
+
+GitHub: https://github.com/escapeboy/boruna
+
+CI/CD runs three jobs on every push: `cargo test --workspace`, `cargo clippy -- -D warnings`, `cargo fmt --check`.
 
 ## Architecture
 
@@ -111,3 +124,4 @@ All are pure-functional (no hidden side effects). Libraries needing capabilities
 - **Capability gating**: Side effects (network, db, fs) are declared and enforced. The VM's `CapabilityGateway` checks every capability call against the active `Policy`.
 - **Replay compatibility**: Execution can be recorded and replayed. `EventLog` captures capability results; `ReplayEngine` verifies determinism.
 - **Package content hashing**: Packages use SHA-256 content hashes for integrity verification.
+- **Path traversal prevention**: PatchBundle validates against `..` and absolute paths, with `canonicalize()` defense-in-depth. LLM cache and context store validate hex-only keys/hashes.


### PR DESCRIPTION
## Summary
- Updated test count from 440+ to 501+ to reflect the actual test suite size
- Added `cargo clippy` and `cargo fmt` commands to the Build & Test section
- Added Repository section with GitHub URL and CI/CD job descriptions
- Added path traversal prevention to Critical Invariants section

## Test plan
- [x] Verify CLAUDE.md renders correctly on GitHub
- [x] Confirm all referenced commands work (`cargo test`, `cargo clippy`, `cargo fmt`)
- [x] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)