### PR TITLE
docs(post-1.0): tracking README + CHANGELOG (T-0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `docs/post-1.0/README.md` describing how post-1.0 work is tracked
+  on GitHub: branch naming, labels, and the project-board scheme.
+- `docs/branch-policy.md` documenting the `master` (1.x LTS) vs.
+  `0.7.x` (speculative) branch topology and cross-merge rules.
+- GitHub labels `wave-1`…`wave-4`, `branch-master`, `branch-0.7.x`,
+  `post1-execution` for filtering post-1.0 PRs and issues.
+
 ## [1.0.0] - 2026-04-28
 
 **First stable release.** The 1.x LTS contract takes effect from

--- a/docs/post-1.0/README.md
+++ b/docs/post-1.0/README.md
@@ -1,0 +1,49 @@
+# Post-1.0 Execution Tracking
+
+This directory hosts public-facing artifacts for work that lands
+on top of `v1.0.0` GA. The candid roadmap and per-task execution
+plan are kept out of the repo — they document trade-offs (e.g.
+"this would break the LTS contract") that operator-facing docs
+deliberately do not contain.
+
+## Where the planning lives
+
+| Source | Visibility | Purpose |
+|--------|------------|---------|
+| [`docs/lts.md`](../lts.md) | Public | LTS commitments operators rely on |
+| [`docs/roadmap.md`](../roadmap.md) | Public | Operator-facing forward look |
+| [`docs/branch-policy.md`](../branch-policy.md) | Public | `master` vs. `0.7.x` topology |
+| `~/Obsidian/.../boruna/post-1.0-roadmap.md` | Internal | Candid lane breakdown |
+| `~/Obsidian/.../boruna/post-1.0-execution-plan.md` | Internal | Per-task execution graph |
+
+## How tasks are tracked on GitHub
+
+Every post-1.0 task gets:
+
+- A branch named `post1/T-<wave>.<n>-<slug>` (e.g.
+  `post1/T-1.1-streaming-progress`).
+- A pull request with the standard CHANGELOG entry under
+  `## [Unreleased]` and an acceptance-criteria checklist in the body.
+- The labels listed below applied for filterability.
+
+### Labels
+
+| Label | Meaning |
+|-------|---------|
+| `post1-execution` | Tracked by the post-1.0 execution plan |
+| `wave-1` … `wave-4` | Which wave the task belongs to |
+| `branch-master` | Lands on `master` (1.x LTS line) |
+| `branch-0.7.x` | Lands on `0.7.x` (speculative parallel work) |
+
+### Project board
+
+A "Post-1.0 Execution" project (Projects v2) tracks task state
+across columns `Wave 1`, `Wave 2`, `Wave 3`, `Wave 4`, `Done`.
+Board creation requires the `project` token scope; if the board is
+not yet linked, the labels above stand in.
+
+## How to find current state
+
+- Open PRs: `gh pr list --label post1-execution`
+- Closed in a wave: `gh pr list --label wave-1 --state merged`
+- 0.7.x work: `gh pr list --base 0.7.x`


### PR DESCRIPTION
## Summary

[T-0.2] of the post-1.0 execution plan. Lands the public-facing
artifacts that surround the rest of the post-1.0 PR series:

- `docs/post-1.0/README.md` — tracking conventions (branches,
  labels, project board) so contributors and operators can read
  the GitHub state without internal Obsidian access.
- `CHANGELOG.md` `[Unreleased]` entry covering this PR plus the
  `docs/branch-policy.md` that landed on `0.7.x` in T-0.1.
- The seven tracking labels (`wave-1`…`wave-4`,
  `branch-master`, `branch-0.7.x`, `post1-execution`) are
  already created on the repo.

## Design assumptions

- The internal Obsidian-only post-1.0-roadmap and execution plan
  are referenced by location only. They contain candid
  "this would break LTS" decisions that operator-facing docs
  must not contain (per `obsidian-planning-vault` memory).
- "Project board" is described as forthcoming because creating
  a Projects v2 board via the GitHub API requires the `project`
  token scope, which my non-interactive environment cannot
  refresh without a browser. Documented as the "Blockers" item
  below; labels stand in for now and the plan-table format works
  fine without a board.

## Acceptance criteria

- [x] Labels created and visible in repo settings (`gh label list`).
- [ ] GitHub Project "Post-1.0 Execution" board created.
- [x] `docs/post-1.0/README.md` renders on github.com.

## Blockers

- **Project board creation blocked on `project` token scope.**
  `gh project create` returned `your authentication token is
  missing required scopes [project read:project]`. This requires
  an interactive `gh auth refresh -s project` which the
  autonomous agent cannot run. The labels carry the same
  filterability burden in the meantime; the `README.md` notes
  the board is forthcoming. The operator can run the refresh
  in a separate session and create the board with the columns
  named in the plan (`Wave 1`, `Wave 2`, `Wave 3`, `Wave 4`,
  `Done`).

## CHANGELOG snippet preview

```
## [Unreleased]

### Added

- docs/post-1.0/README.md describing how post-1.0 work is tracked
  on GitHub: branch naming, labels, and the project-board scheme.
- docs/branch-policy.md documenting the master (1.x LTS) vs.
  0.7.x (speculative) branch topology and cross-merge rules.
- GitHub labels wave-1…wave-4, branch-master, branch-0.7.x,
  post1-execution for filtering post-1.0 PRs and issues.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)