### PR TITLE
ci(post1-T-0.3): bench-compare PR-time regression detection

### DIFF
--- a/.github/scripts/bench_compare.py
+++ b/.github/scripts/bench_compare.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Render a criterion benchmark comparison as a markdown table.
+
+Reads `target/criterion/<group>/<bench>/change/estimates.json` files
+produced by `cargo bench -- --baseline <name>` and emits a markdown
+table summarising the mean change per benchmark. A benchmark is
+flagged as a regression if its mean point-estimate is at least
+`--threshold` (default 0.10 = 10%) slower.
+
+Output is two files:
+- `--out`            markdown comment body
+- `--regressed-out`  one line per regressed benchmark, empty if none
+
+This script intentionally avoids non-stdlib deps so it runs on any
+self-hosted runner with python3 installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def find_change_files(criterion_dir: Path):
+    """Yield (bench_label, change_estimates_path) tuples."""
+    for change in sorted(criterion_dir.rglob("change/estimates.json")):
+        bench_dir = change.parent.parent
+        # Construct a relative bench label: <group>/<bench>
+        rel = bench_dir.relative_to(criterion_dir)
+        yield (str(rel), change)
+
+
+def fmt_pct(x: float) -> str:
+    sign = "+" if x >= 0 else ""
+    return f"{sign}{x * 100:.2f}%"
+
+
+def render_row(label: str, change: dict) -> tuple[str, float]:
+    mean = change["mean"]["point_estimate"]
+    ci = change["mean"]["confidence_interval"]
+    lo = ci["lower_bound"]
+    hi = ci["upper_bound"]
+    return (
+        f"| `{label}` | {fmt_pct(mean)} | [{fmt_pct(lo)}, {fmt_pct(hi)}] |",
+        mean,
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--criterion-dir", type=Path, required=True)
+    p.add_argument("--threshold", type=float, default=0.10)
+    p.add_argument("--out", type=Path, required=True)
+    p.add_argument("--regressed-out", type=Path, required=True)
+    args = p.parse_args()
+
+    if not args.criterion_dir.exists():
+        args.out.write_text(
+            "**Bench compare:** no criterion output found "
+            f"(`{args.criterion_dir}` missing).\n"
+        )
+        args.regressed_out.write_text("")
+        return 0
+
+    rows = []
+    regressed: list[str] = []
+    for label, change_path in find_change_files(args.criterion_dir):
+        try:
+            data = json.loads(change_path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            rows.append((f"| `{label}` | (error: {e}) | — |", 0.0))
+            continue
+        row, mean = render_row(label, data)
+        rows.append((row, mean))
+        if mean >= args.threshold:
+            regressed.append(label)
+
+    lines = [
+        "**Bench compare**",
+        "",
+        f"Threshold for regression: ≥ {args.threshold * 100:.0f}% slower mean.",
+        "",
+        "| Benchmark | Mean change | 99% CI |",
+        "|-----------|-------------|--------|",
+    ]
+    if not rows:
+        lines.append("| _(no benchmarks ran)_ | — | — |")
+    else:
+        lines.extend(row for row, _ in rows)
+
+    if regressed:
+        lines.append("")
+        lines.append(
+            f"⚠️ {len(regressed)} benchmark(s) regressed past threshold:"
+        )
+        for label in regressed:
+            lines.append(f"- `{label}`")
+    else:
+        lines.append("")
+        lines.append("✅ No benchmark regressed past threshold.")
+
+    args.out.write_text("\n".join(lines) + "\n")
+    args.regressed_out.write_text("\n".join(regressed))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -1,0 +1,128 @@
+name: Bench compare
+
+# Sprint T-0.3 of post-1.0-execution-plan: PR-time perf-regression
+# detection. Runs the criterion bench harness on both the PR base
+# and the PR head, then posts a sticky comment with the deltas.
+#
+# Non-blocking by default: this job is NOT in branch protection's
+# required_status_checks set. A regression FAILS the job (so the
+# comment shows red), but does not prevent merging until the team
+# decides to promote it. Reviewers should treat ≥10% regressions
+# as "explain or justify" before merging.
+#
+# CI runner: self-hosted. Production-class hardware will give
+# cleaner deltas than a hosted runner; the 10% threshold is
+# calibrated to be larger than typical noise on this box. See
+# docs/PERFORMANCE.md.
+#
+# Bench-compare runs the full criterion suite. If a PR's perf
+# impact can be reasoned about without bench data (docs, CI
+# workflow tweaks, pure CHANGELOG edits), the path filter below
+# skips this job.
+
+on:
+  pull_request:
+    branches: [master, main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE'
+      - 'CHANGELOG.md'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench-compare:
+    name: Bench compare
+    runs-on: self-hosted
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-bench-
+
+      - name: Bench base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # BASE_REF is the PR's target branch (master/main); it cannot
+          # contain shell metacharacters because branch protection
+          # restricts which branches can be PR targets.
+          git fetch origin "$BASE_REF"
+          git checkout "origin/$BASE_REF"
+          cargo bench -p boruna-benches -- --save-baseline base
+
+      - name: Bench PR head
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # HEAD_SHA is a 40-char git oid extracted by GitHub from the
+          # PR ref, not a user-supplied branch name; safe to checkout.
+          git checkout "$HEAD_SHA"
+          cargo bench -p boruna-benches -- --baseline base
+
+      - name: Render comparison
+        id: cmp
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/bench_compare.py \
+            --criterion-dir target/criterion \
+            --threshold 0.10 \
+            --out comment.md \
+            --regressed-out regressed.txt
+          if [ -s regressed.txt ]; then
+            echo "regressed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "regressed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Body lives on disk; never interpolated through shell.
+          MARKER='<!-- bench-compare:sticky -->'
+          {
+            printf '%s\n' "$MARKER"
+            cat comment.md
+          } > body.md
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
+            | head -1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
+              -F body=@body.md > /dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -F body=@body.md > /dev/null
+          fi
+
+      - name: Fail on regression
+        if: steps.cmp.outputs.regressed == 'true'
+        run: |
+          echo "::error::One or more benchmarks regressed by >= 10%."
+          echo "See the bench-compare PR comment for details."
+          exit 1

--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -69,7 +69,13 @@ jobs:
           # restricts which branches can be PR targets.
           git fetch origin "$BASE_REF"
           git checkout "origin/$BASE_REF"
-          cargo bench -p boruna-benches -- --save-baseline base
+          # Enumerate the criterion bench targets explicitly so the lib's
+          # default test harness (which does not know --save-baseline)
+          # is skipped. Adding a new [[bench]] target requires updating
+          # this list.
+          cargo bench -p boruna-benches \
+            --bench compile --bench vm_throughput --bench evidence \
+            -- --save-baseline base
 
       - name: Bench PR head
         env:
@@ -79,7 +85,9 @@ jobs:
           # HEAD_SHA is a 40-char git oid extracted by GitHub from the
           # PR ref, not a user-supplied branch name; safe to checkout.
           git checkout "$HEAD_SHA"
-          cargo bench -p boruna-benches -- --baseline base
+          cargo bench -p boruna-benches \
+            --bench compile --bench vm_throughput --bench evidence \
+            -- --baseline base
 
       - name: Render comparison
         id: cmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `Bench compare` CI job and `.github/scripts/bench_compare.py` —
+  PR-time perf-regression detection that runs the criterion harness
+  on PR base and head, posts a sticky comment with per-benchmark
+  deltas, and fails on ≥10% mean regression. Non-blocking by
+  default (not in the required-status-checks set). See
+  `CONTRIBUTING.md` § "Reading the bench-compare PR comment".
+
 ## [1.0.0] - 2026-04-28
 
 **First stable release.** The 1.x LTS contract takes effect from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,44 @@ These must not be violated:
 - [ ] `CHANGELOG.md` updated under `[Unreleased]`
 - [ ] New behavior has test coverage
 
+## Reading the bench-compare PR comment
+
+Every PR that touches non-doc code triggers a `Bench compare` job
+that runs the criterion bench harness on the PR base and on the
+PR head, then posts a sticky comment with per-benchmark deltas.
+
+The comment is a simple table:
+
+| Benchmark | Mean change | 99% CI |
+|-----------|-------------|--------|
+| `compile/small_program` | `-1.20%` | `[-3.10%, +0.50%]` |
+| `vm_throughput/loop_1k` | `+0.45%` | `[-1.20%, +2.10%]` |
+
+How to read it:
+
+- **Mean change**: positive means slower, negative means faster.
+  Roughly: `+5%` is "noticeable", `+10%` is the regression
+  threshold, `-10%` is "you sped something up — say so in the
+  PR body."
+- **99% CI**: the confidence interval on the mean. If the CI
+  spans zero, the change is not statistically distinguishable
+  from noise.
+- **Threshold**: 10% slower mean fails the job. The job is
+  intentionally NOT in the required-status-checks set, so a
+  failing `Bench compare` does not block merge by default.
+  Reviewers should ask "is this regression intentional?" and
+  expect a documented answer in the PR body.
+- **CI runner**: bench-compare runs on `self-hosted`. Hosted
+  GitHub runners are noisy enough that the deltas would not be
+  trustworthy; the self-hosted box is a stable reference.
+
+If a `Bench compare` job fails on a PR that is genuinely not
+perf-relevant (a docs-only change misclassified, a test-only
+change), trigger a re-run from the Actions UI. If the
+regression reproduces on a docs-only change, the path filter
+in `.github/workflows/bench-compare.yml` may need tightening —
+file a follow-up issue.
+
 ## License
 
 By contributing, you agree that your contributions are licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

[T-0.3] of the post-1.0 execution plan. Adds a non-blocking
`Bench compare` CI job that runs the criterion harness on the PR
base and the PR head, posts a sticky comment with per-benchmark
deltas, and fails on ≥10% mean regression.

## Design assumptions

- **External action vs. self-contained script.** The plan
  references `boa-dev/criterion-compare-action` as a fallback to
  `bencher.dev`. I went one step simpler — a small Python parser
  (`.github/scripts/bench_compare.py`, ~100 lines, stdlib only)
  that reads criterion's `change/estimates.json` files. This
  removes a third-party action dependency and matches the project's
  existing convention (only `actions/*`, `dtolnay/rust-toolchain`,
  `softprops/action-gh-release` are used elsewhere).
- **Existing CI explicitly does not run benches** ("bench TIMING
  data is the operator's job to capture on a representative
  production-class machine" — note in `.github/workflows/ci.yml`).
  T-0.3's whole point is to flip this stance for the post-1.0 era,
  on the assumption that self-hosted is stable enough for ≥10%
  signal. The threshold is intentionally generous to stay above
  noise on the runner.
- **Non-blocking by default.** This job is NOT in branch
  protection's required-status-checks set. A failing
  `Bench compare` shows red but does not prevent merge. Operator
  can promote it to required after a few PRs of calibration.
- **Path filter.** Skips docs-only / CHANGELOG-only / LICENSE-only
  PRs to avoid wasting bench cycles.
- **Stickiness.** The comment uses an HTML marker so reruns update
  the same comment instead of stacking.

## Acceptance criteria

- [x] `.github/workflows/bench-compare.yml` runs on PR.
- [x] Comments PR with delta (sticky).
- [x] Fails on ≥10% mean regression.
- [x] `CONTRIBUTING.md` documents how to read the comment and
  the threshold rationale.
- [ ] **Synthetic-regression smoke test.** The plan asks for a
  synthetic PR introducing `std::thread::sleep(50ms)` in a hot
  path to verify the wiring end-to-end, then a clean revert.
  Running this autonomously would tie up the self-hosted runner
  for ~30 min × 2 cycles and is left as an operator follow-up
  once this PR is merged. Recommended recipe: branch off master
  post-merge, add `std::thread::sleep(Duration::from_millis(50))`
  inside `Vm::run`, push as draft PR, observe red `Bench compare`
  comment, revert, observe green, close.

## Blockers

- None on this PR. Synthetic-regression verification deferred to
  operator (see Acceptance above).

## CHANGELOG snippet preview

```
### Added

- `Bench compare` CI job and `.github/scripts/bench_compare.py` —
  PR-time perf-regression detection that runs the criterion harness
  on PR base and head, posts a sticky comment with per-benchmark
  deltas, and fails on ≥10% mean regression. Non-blocking by
  default (not in the required-status-checks set). See
  `CONTRIBUTING.md` § "Reading the bench-compare PR comment".
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)