### PR TITLE
feat(post1-T-1.4): boruna run --watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   deltas, and fails on ≥10% mean regression. Non-blocking by
   default (not in the required-status-checks set). See
   `CONTRIBUTING.md` § "Reading the bench-compare PR comment".
+- `boruna run --watch` — re-execute a `.ax` file on every change.
+  Debounces filesystem events to 200ms, prints a
+  `── reloading <path> at HH:MM:SS ──` separator before each rerun,
+  and tolerates per-run errors so the watcher keeps running across
+  fix-and-save cycles. See `docs/reference/cli.md` § Watch mode.
+
 ## [1.0.0] - 2026-04-28
 
 **First stable release.** The 1.x LTS contract takes effect from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -319,6 +325,7 @@ dependencies = [
  "clap",
  "hyper",
  "hyper-util",
+ "notify",
  "rcgen",
  "reqwest",
  "rustls",
@@ -674,6 +681,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +857,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +930,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -1386,6 +1428,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1562,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1598,18 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1624,6 +1718,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1631,6 +1737,25 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1853,7 +1978,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1911,6 +2036,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polyval"
@@ -2144,7 +2275,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2305,7 +2445,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2325,7 +2465,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2752,7 +2892,7 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2849,7 +2989,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3201,7 +3341,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3315,11 +3455,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3333,19 +3482,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3355,9 +3525,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3373,9 +3555,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3385,9 +3579,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3459,7 +3665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,16 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc
 # Dev-only cert generation for the mTLS integration test.
 rcgen = "0.13"
 
+# Filesystem watcher for `boruna run --watch` (post1-T-1.4).
+# Default features are kept enabled here because they are the
+# platform-specific watcher backends (fsevent on macOS, inotify on
+# Linux, ReadDirectoryChanges on Windows) — the crate cannot
+# function without one. ADR 001's default-features-off guideline is
+# intentionally relaxed here for the same reason it is relaxed for
+# `clap` (the `env` feature) and `criterion` (the
+# `cargo_bench_support` feature).
+notify = "6"
+
 # Crate aliases: old directory names → new names for Boruna branding
 # The directory structure stays the same; Cargo.toml names are updated.
 # Rust source uses the new crate names via [dependencies] key aliasing.

--- a/crates/llmvm-cli/Cargo.toml
+++ b/crates/llmvm-cli/Cargo.toml
@@ -61,6 +61,9 @@ hyper = { version = "1", optional = true, features = ["server", "http1", "http2"
 hyper-util = { version = "0.1", optional = true, features = ["server-auto", "tokio"] }
 tower = { version = "0.5", optional = true }
 tower-service = { version = "0.3", optional = true }
+# `boruna run --watch` (post1-T-1.4) — filesystem-watch loop that
+# re-executes a `.ax` file on change.
+notify = { workspace = true }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/llmvm-cli/src/main.rs
+++ b/crates/llmvm-cli/src/main.rs
@@ -84,6 +84,12 @@ enum Command {
         /// also set, replay wins (no network calls happen).
         #[arg(long, conflicts_with = "record_net_to")]
         replay_net_from: Option<PathBuf>,
+        /// Re-run the file on every change. Watch mode prints a
+        /// separator before each rerun and continues until Ctrl-C.
+        /// Errors in a single run do not exit watch mode — fix the
+        /// file and the next save will re-execute.
+        #[arg(long)]
+        watch: bool,
     },
     /// Run with execution tracing enabled.
     Trace {
@@ -1120,44 +1126,30 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             live,
             record_net_to,
             replay_net_from,
+            watch,
         } => {
-            let module = load_module(&file)?;
-            let gateway = make_gateway(
+            if watch {
+                run_watch_loop(
+                    &file,
+                    &policy,
+                    max_steps,
+                    record.as_deref(),
+                    live,
+                    record_net_to.as_deref(),
+                    replay_net_from.as_deref(),
+                )?;
+            } else if let Err(e) = run_once(
+                &file,
                 &policy,
+                max_steps,
+                record.as_deref(),
                 live,
                 record_net_to.as_deref(),
                 replay_net_from.as_deref(),
-            )?;
-            let mut vm = Vm::new(module, gateway);
-            vm.set_max_steps(max_steps);
-
-            match vm.run() {
-                Ok(result) => {
-                    println!("{result}");
-                    if !vm.ui_output.is_empty() {
-                        println!("\n--- UI Output ---");
-                        for tree in &vm.ui_output {
-                            let json = serde_json::to_string_pretty(tree)?;
-                            println!("{json}");
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!("runtime error: {e}");
-                    process::exit(1);
-                }
+            ) {
+                eprintln!("{e}");
+                process::exit(1);
             }
-
-            if let Some(log_path) = record {
-                let json = vm
-                    .event_log()
-                    .to_json()
-                    .map_err(|e| format!("failed to serialize event log: {e}"))?;
-                fs::write(&log_path, json)?;
-                println!("events recorded to {}", log_path.display());
-            }
-
-            println!("steps: {}", vm.step_count());
         }
         Command::Trace { file } => {
             let module = load_module(&file)?;
@@ -2414,6 +2406,186 @@ fn make_gateway(
     }
 
     Ok(CapabilityGateway::new(policy))
+}
+
+/// Compile and execute the file once. Returns Err on compile or
+/// runtime failure; the caller decides whether to exit (single-run
+/// mode) or print and continue (watch mode).
+fn run_once(
+    file: &PathBuf,
+    policy: &str,
+    max_steps: u64,
+    record: Option<&std::path::Path>,
+    live: bool,
+    record_net_to: Option<&std::path::Path>,
+    replay_net_from: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let module = load_module(file)?;
+    let gateway = make_gateway(policy, live, record_net_to, replay_net_from)?;
+    let mut vm = Vm::new(module, gateway);
+    vm.set_max_steps(max_steps);
+
+    match vm.run() {
+        Ok(result) => {
+            println!("{result}");
+            if !vm.ui_output.is_empty() {
+                println!("\n--- UI Output ---");
+                for tree in &vm.ui_output {
+                    let json = serde_json::to_string_pretty(tree)?;
+                    println!("{json}");
+                }
+            }
+        }
+        Err(e) => {
+            return Err(format!("runtime error: {e}").into());
+        }
+    }
+
+    if let Some(log_path) = record {
+        let json = vm
+            .event_log()
+            .to_json()
+            .map_err(|e| format!("failed to serialize event log: {e}"))?;
+        fs::write(log_path, json)?;
+        println!("events recorded to {}", log_path.display());
+    }
+
+    println!("steps: {}", vm.step_count());
+    Ok(())
+}
+
+/// Watch a `.ax` file and re-execute on change.
+///
+/// Debounces filesystem events to 200ms so a single editor save
+/// (which often produces multiple inotify/fsevent events) triggers
+/// exactly one rerun. Errors in a single run print to stderr but do
+/// NOT exit the loop — the user fixes the file and the next save
+/// re-executes. Ctrl-C exits cleanly via the default SIGINT handler.
+fn run_watch_loop(
+    file: &PathBuf,
+    policy: &str,
+    max_steps: u64,
+    record: Option<&std::path::Path>,
+    live: bool,
+    record_net_to: Option<&std::path::Path>,
+    replay_net_from: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::sync::mpsc::{channel, RecvTimeoutError};
+    use std::time::{Duration, Instant};
+
+    use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+    let canonical = file
+        .canonicalize()
+        .map_err(|e| format!("--watch: cannot resolve {}: {e}", file.display()))?;
+    let display = display_relative(file);
+
+    print_reload_banner(&display);
+    if let Err(e) = run_once(
+        file,
+        policy,
+        max_steps,
+        record,
+        live,
+        record_net_to,
+        replay_net_from,
+    ) {
+        eprintln!("{e}");
+    }
+
+    let (tx, rx) = channel::<notify::Result<Event>>();
+    let mut watcher: RecommendedWatcher = Watcher::new(
+        move |res| {
+            // Send errors are unrecoverable (rx dropped); ignore them
+            // because we're about to exit.
+            let _ = tx.send(res);
+        },
+        notify::Config::default(),
+    )?;
+    // Watching the parent directory non-recursively makes editors
+    // that write atomically (rename-into-place) work reliably; the
+    // event filter then drops anything not matching our file.
+    let watch_root = canonical
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| canonical.clone());
+    watcher.watch(&watch_root, RecursiveMode::NonRecursive)?;
+
+    let debounce = Duration::from_millis(200);
+
+    loop {
+        // Block waiting for the first event after a settle period.
+        let event = match rx.recv() {
+            Ok(Ok(ev)) => ev,
+            Ok(Err(e)) => {
+                eprintln!("watch error: {e}");
+                continue;
+            }
+            Err(_) => break, // sender dropped; exit
+        };
+
+        if !event_touches(&event, &canonical) {
+            continue;
+        }
+
+        // Debounce: drain any further events arriving within the
+        // 200ms window so a flurry of saves becomes one rerun.
+        let deadline = Instant::now() + debounce;
+        loop {
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            if timeout.is_zero() {
+                break;
+            }
+            match rx.recv_timeout(timeout) {
+                Ok(_) => continue, // drain
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Disconnected) => return Ok(()),
+            }
+        }
+
+        print_reload_banner(&display);
+        if let Err(e) = run_once(
+            file,
+            policy,
+            max_steps,
+            record,
+            live,
+            record_net_to,
+            replay_net_from,
+        ) {
+            eprintln!("{e}");
+        }
+    }
+
+    Ok(())
+}
+
+fn event_touches(event: &notify::Event, target: &std::path::Path) -> bool {
+    event
+        .paths
+        .iter()
+        .any(|p| p.canonicalize().ok().as_deref() == Some(target))
+}
+
+fn print_reload_banner(display: &str) {
+    use std::time::SystemTime;
+    let secs = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let h = (secs / 3600) % 24;
+    let m = (secs / 60) % 60;
+    let s = secs % 60;
+    println!("── reloading {display} at {h:02}:{m:02}:{s:02} ──");
+}
+
+fn display_relative(file: &std::path::Path) -> String {
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Ok(rel) = file.strip_prefix(&cwd) {
+            return rel.display().to_string();
+        }
+    }
+    file.display().to_string()
 }
 
 fn run_workflow(

--- a/crates/llmvm-cli/tests/cli_watch.rs
+++ b/crates/llmvm-cli/tests/cli_watch.rs
@@ -1,0 +1,112 @@
+//! Integration test for `boruna run --watch` (post1-T-1.4).
+//!
+//! Spawns the CLI under watch mode, modifies the watched `.ax` file,
+//! and asserts a second run is observed within a short window. This
+//! is timing-dependent — the deadline is generous so a busy CI
+//! runner does not flake.
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc, Arc,
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::tempdir;
+
+fn boruna_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_boruna")
+}
+
+const PROGRAM_V1: &str = "fn main() -> Int {\n    1\n}\n";
+const PROGRAM_V2: &str = "fn main() -> Int {\n    2\n}\n";
+
+/// Watch mode reruns the file when it changes.
+///
+/// Layout of the test:
+///   1. Write `1.ax` containing PROGRAM_V1.
+///   2. Spawn `boruna run --watch 1.ax`. Capture stdout line-by-line.
+///   3. Wait for the first reload banner (initial run).
+///   4. Overwrite the file with PROGRAM_V2.
+///   5. Assert a second reload banner appears within 5 seconds.
+///   6. Kill the child.
+#[test]
+fn watch_reruns_on_file_change() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("watched.ax");
+    fs::write(&path, PROGRAM_V1).expect("write initial");
+
+    let mut child = Command::new(boruna_bin())
+        .args(["run", "--watch"])
+        .arg(&path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn boruna");
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let (line_tx, line_rx) = mpsc::channel::<String>();
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_thread = stop.clone();
+    let reader = thread::spawn(move || {
+        let mut br = BufReader::new(stdout);
+        let mut buf = String::new();
+        while !stop_thread.load(Ordering::Relaxed) {
+            buf.clear();
+            match br.read_line(&mut buf) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let _ = line_tx.send(buf.trim_end().to_string());
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let banner_count = |deadline: Instant| -> usize {
+        let mut count = 0;
+        while Instant::now() < deadline {
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            match line_rx.recv_timeout(timeout) {
+                Ok(line) => {
+                    if line.contains("reloading") {
+                        count += 1;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => break,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        count
+    };
+
+    // Wait up to 5s for the initial banner (first run on launch).
+    let initial = banner_count(Instant::now() + Duration::from_secs(5));
+    assert!(
+        initial >= 1,
+        "expected initial reload banner, observed {initial}"
+    );
+
+    // Modify the file. Some platforms collapse adjacent fsevents, so
+    // we sleep briefly first and use a real overwrite (not append) so
+    // the inode's mtime advances.
+    thread::sleep(Duration::from_millis(300));
+    fs::write(&path, PROGRAM_V2).expect("write update");
+
+    // Wait up to 5s for a second banner.
+    let after = banner_count(Instant::now() + Duration::from_secs(5));
+    let total_after_modify = initial + after;
+    assert!(
+        total_after_modify >= 2,
+        "expected >=2 reload banners (initial + post-edit), observed {total_after_modify}"
+    );
+
+    // Tear down.
+    stop.store(true, Ordering::Relaxed);
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -62,6 +62,7 @@ Options:
   --live             Enable real capability handlers (requires http feature)
   --trace            Emit a full execution trace to stdout
   --step-limit <n>   Abort if execution exceeds n steps
+  --watch            Re-run on every change to the file (post-1.0)
 ```
 
 Examples:
@@ -75,7 +76,31 @@ boruna run app.ax --policy allow-all
 
 # Run with real HTTP (requires --features boruna-cli/http)
 cargo run --features boruna-cli/http --bin boruna -- run app.ax --policy allow-all --live
+
+# Watch mode — re-run on every save until Ctrl-C
+boruna run app.ax --watch
 ```
+
+### Watch mode
+
+`--watch` re-executes the file on every change. Filesystem events
+are debounced to 200ms, so a single editor save triggers exactly
+one rerun even on platforms that emit a flurry of events per save.
+
+A separator line marks each rerun:
+
+```
+── reloading app.ax at 14:03:11 ──
+3
+steps: 4
+```
+
+A failed run (compile error or runtime panic) does **not** exit
+watch mode — the error is printed and the watcher waits for the
+next save. Press `Ctrl-C` to exit.
+
+Watch combines with the standard run flags:
+`boruna run app.ax --watch --policy ./policy.json --record events.json`.
 
 ---
 


### PR DESCRIPTION
## Summary

[T-1.4] of the post-1.0 execution plan. Adds `--watch` to
`boruna run <file.ax>`, re-executing the file on every change
until Ctrl-C.

## Design assumptions

- **Single-file watch.** The plan mentions watching "any `.ax` file
  referenced (via the dependency graph the compiler already
  computes)". `boruna run` operates on a single `.ax` file with no
  multi-module imports in 1.0 — the compiler does not currently
  expose a public dependency graph for a single source. T-1.4
  watches just the named file. A multi-file watch is a clean
  follow-up if/when modular imports land.
- **Watch the parent directory, filter by canonical path.** Atomic
  rename-into-place editors (vim, common IDEs) do not emit events
  on the file's inode; they create a new inode and rename. Watching
  the parent directory and filtering events by canonical path
  catches both styles.
- **200ms debounce.** Per the plan. A single editor save often
  emits 2-4 fsevents on macOS, 1-3 inotify events on Linux. 200ms
  is enough to coalesce a save, fast enough to feel instant.
- **Errors do not exit watch mode.** A compile error or runtime
  panic prints to stderr and the loop continues; the next save
  re-executes. This matches the dev workflow (fix file, save,
  see result).
- **Ctrl-C uses default SIGINT handling.** No `ctrlc` crate. The
  default behavior tears down notify cleanly.

## Acceptance criteria

- [x] Manual test recipe in `docs/reference/cli.md` § Watch mode.
- [x] Integration test (`crates/llmvm-cli/tests/cli_watch.rs`)
  using a tempdir + subprocess: write file, observe initial run,
  rewrite file, assert second reload banner appears within 5s
  (deadline generous for CI noise).
- [x] CHANGELOG entry under "Added".

## Local gates

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p boruna-cli` — 1 passed (cli_watch), other
  cli suites passed unchanged. `cargo test --workspace` running
  in background; expected to pass since changes are confined to
  `boruna-cli` and a workspace dep addition.
- [ ] `cargo bench --no-run --workspace` — relies on CI's existing
  "Compile benches (no-run)" step.

## CHANGELOG snippet preview

```
### Added

- `boruna run --watch` — re-execute a `.ax` file on every change.
  Debounces filesystem events to 200ms, prints a
  `── reloading <path> at HH:MM:SS ──` separator before each rerun,
  and tolerates per-run errors so the watcher keeps running across
  fix-and-save cycles. See `docs/reference/cli.md` § Watch mode.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)