### PR TITLE
ci(post1-T-1.6): container-based musl smoke-test workflow

### DIFF
--- a/.github/scripts/smoke_musl.sh
+++ b/.github/scripts/smoke_musl.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Smoke-test a published Boruna release artifact for one Linux musl
+# target. Invoked from .github/workflows/smoke-musl.yml.
+#
+# Usage:
+#   smoke_musl.sh <tag> <target-triple> <docker-image> <kind>
+#
+# Where:
+#   <tag>            e.g. v1.0.0-rc2
+#   <target-triple>  e.g. x86_64-unknown-linux-musl
+#   <docker-image>   e.g. alpine:3.19 or arm64v8/alpine:3.19
+#   <kind>           "native" (real platform) or "emulated" (qemu)
+#
+# Outputs `docs/release-smoke-tests/<tag>-musl-<arch>.md`.
+#
+# The shape of the report mirrors `docs/release-smoke-tests/v1.0.0-rc2.md`
+# (the macOS arm64 reference) — sections: Scope, Steps performed,
+# Findings, Verdict.
+
+set -euo pipefail
+
+TAG="${1:?missing tag}"
+TARGET="${2:?missing target triple}"
+IMAGE="${3:?missing docker image}"
+KIND="${4:?missing kind (native|emulated)}"
+
+case "$TARGET" in
+  x86_64-unknown-linux-musl) ARCH="x86_64" ;;
+  aarch64-unknown-linux-musl) ARCH="aarch64" ;;
+  *) echo "ERROR: unsupported target $TARGET" >&2; exit 1 ;;
+esac
+
+# Strip the leading 'v' so version-bearing filenames match the
+# release-pipeline's naming convention.
+VERSION="${TAG#v}"
+ARTIFACT="boruna-${VERSION}-${TARGET}.tar.gz"
+RELEASE_URL="https://github.com/escapeboy/boruna/releases/download/${TAG}"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+REPORT_DIR="$REPO_ROOT/docs/release-smoke-tests"
+mkdir -p "$REPORT_DIR"
+REPORT="$REPORT_DIR/${TAG}-musl-${ARCH}.md"
+
+cd "$WORK"
+
+echo "::group::download $ARTIFACT"
+curl -sSLf -o "$ARTIFACT" "$RELEASE_URL/$ARTIFACT"
+curl -sSLf -o SHA256SUMS "$RELEASE_URL/SHA256SUMS"
+echo "::endgroup::"
+
+# Extract the line for our artifact and verify.
+EXPECTED=$(grep -E "  ${ARTIFACT}\$" SHA256SUMS | awk '{print $1}')
+COMPUTED=$(sha256sum "$ARTIFACT" | awk '{print $1}')
+
+if [ "$EXPECTED" != "$COMPUTED" ]; then
+  echo "ERROR: SHA256 mismatch" >&2
+  echo "  expected: $EXPECTED" >&2
+  echo "  computed: $COMPUTED" >&2
+  exit 1
+fi
+
+echo "::group::extract"
+mkdir -p extracted
+tar -xzf "$ARTIFACT" -C extracted
+ls -la extracted
+echo "::endgroup::"
+
+# Run the binary inside the target container so the libc/loader is
+# the actual musl runtime, not the host's glibc. We bind-mount the
+# extracted dir and the workflow examples.
+echo "::group::run in $IMAGE"
+docker pull "$IMAGE"
+
+# Capture binary version + capability list.
+VERSION_OUT=$(docker run --rm \
+  -v "$WORK/extracted:/boruna:ro" \
+  "$IMAGE" /boruna/boruna --version)
+
+CAP_OUT=$(docker run --rm \
+  -v "$WORK/extracted:/boruna:ro" \
+  "$IMAGE" /boruna/boruna capability list 2>&1 || true)
+
+# Run an example workflow + verify evidence.
+WORKFLOW_OUT=$(docker run --rm \
+  -v "$WORK/extracted:/boruna:ro" \
+  -v "$REPO_ROOT/examples:/examples:ro" \
+  "$IMAGE" sh -c '
+    set -e
+    mkdir -p /tmp/data /tmp/evidence
+    /boruna/boruna workflow run /examples/workflows/llm_code_review \
+      --policy allow-all \
+      --record \
+      --data-dir /tmp/data \
+      --evidence-dir /tmp/evidence
+    run_id=$(ls /tmp/evidence | head -1)
+    /boruna/boruna evidence verify "/tmp/evidence/$run_id"
+  ' 2>&1)
+echo "::endgroup::"
+
+# Capture command output as files so we can sed-prefix them into the
+# report block without losing line breaks.
+echo "$CAP_OUT" | head -20 | sed 's/^/   /' > cap_out.indented
+echo "$WORKFLOW_OUT" | tail -20 | sed 's/^/   /' > workflow_out.indented
+CAP_BLOCK=$(cat cap_out.indented)
+WORKFLOW_BLOCK=$(cat workflow_out.indented)
+
+NOTE=""
+if [ "$KIND" = "emulated" ]; then
+  NOTE='> **Note:** this report runs the binary under qemu-user-static
+> emulation. It exercises the userspace musl libc and the binary
+> itself, but NOT the kernel/silicon combination an aarch64
+> operator would actually deploy on. Real-hardware smoke on real
+> aarch64 silicon (Pi, Graviton, ...) remains operator-side.
+
+'
+fi
+
+cat > "$REPORT" <<EOF
+# ${TAG} Release Smoke-Test Report (musl ${ARCH})
+
+Performed: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+Performed by: \`.github/workflows/smoke-musl.yml\` (${KIND} run, image \`${IMAGE}\`).
+
+## Scope
+
+Container-based verification that the GitHub Releases artifact for \`${TAG}\`
+on target \`${TARGET}\` works as published — checksum integrity, binary
+launches inside the target's musl loader, example workflow runs to
+completion, evidence bundle verifies.
+
+This is the automated counterpart to the operator-side smoke test on
+real Alpine + aarch64 hardware described in
+[\`docs/release-smoke-tests/v1.0.0-rc2.md\`](./v1.0.0-rc2.md). It catches
+regressions a hosted CI run would catch (broken artifact, missing
+loader, tarball layout drift) without standing in for real-hardware
+verification.
+
+${NOTE}## Steps performed
+
+1. **Download** \`SHA256SUMS\` and \`${ARTIFACT}\` from
+   <${RELEASE_URL}>.
+2. **Verify** the SHA-256 digest matches:
+   - Expected: \`${EXPECTED}\`
+   - Computed: \`${COMPUTED}\`
+   - **Match: ✓**
+3. **Extract** the tarball.
+4. **Run** \`boruna --version\` inside \`${IMAGE}\`:
+   \`\`\`
+   ${VERSION_OUT}
+   \`\`\`
+5. **Run** \`boruna capability list\`. Output:
+   \`\`\`
+${CAP_BLOCK}
+   \`\`\`
+6. **Run** the \`llm_code_review\` example workflow with
+   \`--policy allow-all --record\`, then \`evidence verify\`. Output (tail):
+   \`\`\`
+${WORKFLOW_BLOCK}
+   \`\`\`
+
+## Verdict
+
+The published \`${TARGET}\` artifact for \`${TAG}\` is **container-fit**:
+checksum verified, binary executes under the musl loader, the example
+workflow runs to completion, and the evidence bundle verifies.
+
+Real-hardware verification on Alpine x86_64 / aarch64 hardware remains
+operator-side per
+[\`docs/release-smoke-tests/v1.0.0-rc2.md\`](./v1.0.0-rc2.md) §
+"Targets NOT covered by this smoke test".
+EOF
+
+echo "wrote $REPORT"

--- a/.github/workflows/smoke-musl.yml
+++ b/.github/workflows/smoke-musl.yml
@@ -1,0 +1,169 @@
+name: Smoke test (musl)
+
+# Sprint T-1.6 of post-1.0-execution-plan: container-based smoke
+# tests for the Linux musl release artifacts.
+#
+# Triggers on rc tags so each release-candidate cut produces a
+# fresh report. Operator may also dispatch manually for an existing
+# tag via workflow_dispatch.
+#
+# Two targets:
+#   1. x86_64-unknown-linux-musl, run natively under alpine:3.19.
+#   2. aarch64-unknown-linux-musl, run via qemu-user-static. NOT a
+#      real-hardware smoke; the report annotates this. Real-hardware
+#      smoke on actual aarch64 silicon stays operator-side.
+#
+# After both jobs finish, a final job opens a PR with the new
+# reports.
+
+on:
+  push:
+    tags:
+      - 'v*-rc*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to smoke-test (e.g. v1.0.0-rc2)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  smoke-x86_64:
+    name: Smoke (x86_64-unknown-linux-musl)
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: tag
+        env:
+          REF: ${{ github.ref }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_TAG:-}" ]; then
+            printf 'tag=%s\n' "$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            printf 'tag=%s\n' "${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run smoke
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          TARGET: x86_64-unknown-linux-musl
+          IMAGE: alpine:3.19
+          KIND: native
+        run: |
+          set -euo pipefail
+          .github/scripts/smoke_musl.sh "$TAG" "$TARGET" "$IMAGE" "$KIND"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report-x86_64
+          path: docs/release-smoke-tests/${{ steps.tag.outputs.tag }}-musl-x86_64.md
+
+  smoke-aarch64:
+    name: Smoke (aarch64-unknown-linux-musl, emulated)
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: tag
+        env:
+          REF: ${{ github.ref }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_TAG:-}" ]; then
+            printf 'tag=%s\n' "$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            printf 'tag=%s\n' "${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up qemu-user-static
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install arm64 || true
+
+      - name: Run smoke (qemu)
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          TARGET: aarch64-unknown-linux-musl
+          IMAGE: arm64v8/alpine:3.19
+          KIND: emulated
+        run: |
+          set -euo pipefail
+          .github/scripts/smoke_musl.sh "$TAG" "$TARGET" "$IMAGE" "$KIND"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report-aarch64
+          path: docs/release-smoke-tests/${{ steps.tag.outputs.tag }}-musl-aarch64.md
+
+  open-pr:
+    name: Open PR with reports
+    needs: [smoke-x86_64, smoke-aarch64]
+    runs-on: self-hosted
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        env:
+          REF: ${{ github.ref }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_TAG:-}" ]; then
+            printf 'tag=%s\n' "$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            printf 'tag=%s\n' "${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download reports
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/smoke-reports
+
+      - name: Move reports into tree
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p docs/release-smoke-tests
+          # download-artifact creates one subdir per artifact name.
+          for src in /tmp/smoke-reports/*/*.md; do
+            cp "$src" docs/release-smoke-tests/
+          done
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          BRANCH="post1/T-1.6-smoke-${TAG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add docs/release-smoke-tests/
+          if git diff --staged --quiet; then
+            echo "no report changes; skipping PR"
+            exit 0
+          fi
+          git commit -m "docs(release-smoke): add musl smoke reports for ${TAG}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "docs(release-smoke): musl smoke reports for ${TAG}" \
+            --body "Auto-generated by .github/workflows/smoke-musl.yml on tag ${TAG}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   deltas, and fails on ≥10% mean regression. Non-blocking by
   default (not in the required-status-checks set). See
   `CONTRIBUTING.md` § "Reading the bench-compare PR comment".
+- `Smoke test (musl)` CI workflow and `.github/scripts/smoke_musl.sh`
+  — automated container-based smoke tests for the
+  `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`
+  release artifacts. Runs on every `v*-rc*` tag (or via
+  `workflow_dispatch` for an existing tag), verifies SHA-256,
+  launches the binary under `alpine:3.19`, runs the
+  `llm_code_review` example end-to-end, verifies the evidence
+  bundle, and opens a PR with `docs/release-smoke-tests/<tag>-musl-<arch>.md`
+  reports. The aarch64 leg runs under qemu-user-static and is
+  explicitly NOT a real-hardware smoke; that remains operator-side.
+
 ## [1.0.0] - 2026-04-28
 
 **First stable release.** The 1.x LTS contract takes effect from


### PR DESCRIPTION
## Summary

[T-1.6] of the post-1.0 execution plan. Adds an automated
container-based smoke test for the two Linux musl release
artifacts. Triggers on `v*-rc*` tags and via `workflow_dispatch`
for an existing tag.

## Design assumptions

- **Self-hosted runner.** Same box as the rest of CI. Hosted
  runners would also work, but then the smoke test would not
  share its cargo cache with the existing CI jobs.
- **alpine:3.19.** Matches the historical "Alpine on real
  hardware" smoke target. Bumping Alpine to a newer minor is a
  one-line change in `smoke_musl.sh`.
- **aarch64 via qemu-user-static.** The plan acknowledges this
  is emulation, not real hardware. The generated report carries
  a prominent `> Note:` block flagging the limitation, and the
  workflow comments link to operator-side guidance for a
  real-hardware pass.
- **PR opener uses GITHUB_TOKEN.** The workflow's automatic
  `GITHUB_TOKEN` has `contents: write` and `pull-requests: write`
  granted on the `permissions:` block. No separate PAT needed.
- **Report shape mirrors `docs/release-smoke-tests/v1.0.0-rc2.md`.**
  The reference file is the macOS arm64 smoke. Our reports use
  the same Scope / Steps performed / Verdict structure so they
  read uniformly when filed side-by-side.

## Acceptance criteria

- [x] `.github/workflows/smoke-musl.yml` triggers on `v*-rc*` tags
  AND on `workflow_dispatch` with a `tag:` input.
- [x] Two jobs run in parallel: native x86_64 musl + emulated
  aarch64 musl.
- [x] Each job verifies SHA-256, extracts, launches the binary
  inside the target container, runs `llm_code_review`, verifies
  evidence.
- [x] A final `open-pr` job collects both reports as artifacts and
  opens a PR.
- [x] CHANGELOG entry under "Added".
- [ ] **End-to-end verification by `workflow_dispatch` against an
  existing tag.** Cannot run autonomously — requires the
  self-hosted runner to be available for ~30 min and the operator
  to confirm the resulting PR. Recipe: `gh workflow run
  smoke-musl.yml -F tag=v1.0.0-rc2` after this PR merges.

## Blockers

- None on this PR. Operator follow-up to verify by triggering
  `workflow_dispatch` on `v1.0.0-rc2` once merged.

## CHANGELOG snippet preview

```
- Smoke test (musl) CI workflow and .github/scripts/smoke_musl.sh —
  automated container-based smoke tests for the
  x86_64-unknown-linux-musl and aarch64-unknown-linux-musl
  release artifacts. (...)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)