### PR TITLE
docs(post1-T-1.1): formalize boruna_run MCP progress notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `boruna_run` MCP progress notifications are now part of the 1.x
+  LTS-stable surface (post1-T-1.1). When a client supplies the
+  standard MCP `progressToken` in the request's `_meta` field, the
+  server drives the VM in ~100k-opcode slices and emits
+  `notifications/progress` events between slices with the cumulative
+  step count. The underlying mechanism shipped in sprint 0.4-S6;
+  this entry formalizes the wire contract and adds reference docs
+  in `docs/reference/mcp-server.md` § "Progress notifications".
 - Worker capability advertisements now carry an optional version
   (post1-T-1.3). `RegisterRequest.advertised_capabilities` accepts
   either a bare string (legacy worker, normalized by the coord to

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -185,6 +185,35 @@ Plus the `errors` shape from `boruna_compile` if compilation fails before the ru
 
 `Value::List` becomes a JSON array; `Value::Map` becomes a JSON object.
 
+**Progress notifications** (formalized as 1.x stable in
+post1-T-1.1; underlying mechanism shipped in sprint 0.4-S6).
+
+When the caller includes a `progressToken` in the request's `_meta`
+field — the standard MCP mechanism for streaming progress — the
+server drives the VM through `Vm::execute_bounded` in slices of
+~100,000 opcodes. Between slices it emits MCP
+`notifications/progress` events whose `progress` field is the
+cumulative VM step count:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "<echoed from request>",
+    "progress": 142000
+  }
+}
+```
+
+The events are coarse — slice-bounded, not per-opcode — so a
+long-running script emits several events per second on typical
+hardware. Clients that don't supply a `progressToken` see no
+notifications and no extra latency. The streaming and non-streaming
+paths share their semantics for `start_time`, `max_wall_ms`, error
+handling, and final response shape, so progress-aware clients see
+identical results to legacy clients on the same input.
+
 ---
 
 ### `boruna_check`


### PR DESCRIPTION
## Summary

[T-1.1] of the post-1.0 execution plan. Formalizes the streaming
progress notifications already shipped in sprint 0.4-S6 (closed
issue #4) as a 1.x LTS-stable surface.

## Design assumptions

- **Use MCP-standard `progressToken`, not a custom
  `progress_events: bool` parameter.** The existing 0.4-S6
  implementation drives progress notifications via the standard
  MCP `progressToken` in the request's `_meta` field. This is
  preferred over a Boruna-specific boolean flag because:
  1. Clients implement progress handling once and work with all
     MCP servers (no Boruna-specific client code).
  2. The MCP standard already defines the notification shape; we
     don't fork.
  3. The plan's design notes were written before discovery of
     0.4-S6's existing implementation.
- **Notification format is MCP-standard `notifications/progress`,
  not the plan's custom `{"event":"progress","step_id":"..."}`
  shape.** Same rationale: standards over forks.
- **No new `progress_events_capability: "1.0"` advertisement.**
  Clients detect support via the standard MCP capability handshake;
  introducing a Boruna-specific advertisement would duplicate that.
- **`boruna_run` runs a single `.ax` file**, not a multi-step
  workflow. The plan mentions "3-step workflow" testing but the
  closest analog in 1.x is the slice-bounded VM driver, which
  emits several progress events per second on long-running
  scripts (the canonical use case).

## Acceptance criteria

- [x] `docs/reference/mcp-server.md` documents the progress
  notification protocol under `boruna_run`.
- [x] CHANGELOG entry under "Added" formalizing the streaming
  capability as part of the 1.x LTS surface.
- [x] Existing tests in `crates/boruna-mcp/src/tools/run.rs`
  (`run_source_with_progress_callback_*`) cover the streaming
  path; no functional changes needed in this PR.

## Local gates

- [x] No code changes in this PR (docs+CHANGELOG only).

## CHANGELOG snippet preview

```
### Added

- `boruna_run` MCP progress notifications are now part of the 1.x
  LTS-stable surface (post1-T-1.1). When a client supplies the
  standard MCP progressToken in the request's _meta field, the
  server drives the VM in ~100k-opcode slices and emits
  notifications/progress events between slices with the cumulative
  step count. The underlying mechanism shipped in sprint 0.4-S6;
  this entry formalizes the wire contract and adds reference docs
  in docs/reference/mcp-server.md § "Progress notifications".
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)