### PR TITLE
feat(post1-T-2.4): boruna evidence rotate-kek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `boruna evidence rotate-kek` (post1-T-2.4) re-wraps the DEK of one
+  or more encrypted evidence bundles under a new KEK. Operations are
+  manifest-only — per-file ciphertext stays valid because the DEK
+  itself is unchanged. Supports single-bundle and batch (directory)
+  modes; batch mode runs in parallel via rayon, bounded by
+  `--parallelism N` (default `min(8, num_cpus)`). `--dry-run`
+  validates without writing. `--kek-id-from <id>` defends against
+  accidental double-rotation in mixed-state batches. New
+  `Envelope::rewrap` API on the encryption module exposes the same
+  primitive to library consumers. See
+  `docs/guides/kek-rotation.md`.
 - Pluggable evidence-bundle storage trait `BundleStorage` and a
   `LocalFs` adapter (post1-T-2.3). `boruna workflow run --record`
   now accepts `--bundle-storage <uri>` (or `BORUNA_BUNDLE_STORAGE`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "clap",
  "libc",
  "rand_core 0.6.4",
+ "rayon",
  "rusqlite",
  "serde",
  "serde_json",
@@ -687,6 +688,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2267,6 +2287,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/crates/llmvm-cli/src/main.rs
+++ b/crates/llmvm-cli/src/main.rs
@@ -946,6 +946,38 @@ enum EvidenceCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Rotate the KEK on one or more encrypted evidence bundles
+    /// (post1-T-2.4). Unwraps the DEK with the old KEK, re-wraps it
+    /// under the new KEK, and atomically rewrites each bundle's
+    /// `manifest.json`. Per-file ciphertext is unchanged because
+    /// the DEK itself does not change.
+    RotateKek {
+        /// Bundle directory (single bundle) OR a directory whose
+        /// immediate subdirectories are bundles (batch mode).
+        target: PathBuf,
+        /// Old KEK as 64 hex chars. Required.
+        #[arg(long, value_name = "HEX")]
+        old_kek: String,
+        /// New KEK as 64 hex chars. Required.
+        #[arg(long, value_name = "HEX")]
+        new_kek: String,
+        /// Refuse to rotate any bundle whose current `kek_id` does
+        /// not equal this value. Use to defend against accidental
+        /// double-rotation in mixed-state batches.
+        #[arg(long, value_name = "ID")]
+        kek_id_from: Option<String>,
+        /// `kek_id` to write into the rotated manifest. Defaults
+        /// to `"default"` matching `--encrypt-bundle`.
+        #[arg(long, value_name = "ID", default_value = "default")]
+        kek_id_to: String,
+        /// Print planned actions but do not modify any bundle.
+        #[arg(long)]
+        dry_run: bool,
+        /// Maximum bundles processed in parallel in batch mode.
+        /// Default `min(8, num_cpus)`.
+        #[arg(long, value_name = "N")]
+        parallelism: Option<usize>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -3661,8 +3693,128 @@ fn run_evidence(
                 return Err("`evidence gc-blobs` requires the `persist-sqlite` feature".into());
             }
         }
+        EvidenceCommand::RotateKek {
+            target,
+            old_kek,
+            new_kek,
+            kek_id_from,
+            kek_id_to,
+            dry_run,
+            parallelism,
+        } => {
+            run_evidence_rotate_kek(
+                target,
+                &old_kek,
+                &new_kek,
+                kek_id_from,
+                kek_id_to,
+                dry_run,
+                parallelism,
+            )?;
+        }
     }
     Ok(())
+}
+
+/// `boruna evidence rotate-kek` (post1-T-2.4). Dispatches to
+/// single-bundle or batch (directory of bundles) rotation based on
+/// what `target` points at.
+fn run_evidence_rotate_kek(
+    target: PathBuf,
+    old_kek_hex: &str,
+    new_kek_hex: &str,
+    kek_id_from: Option<String>,
+    kek_id_to: String,
+    dry_run: bool,
+    parallelism: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use boruna_orchestrator::audit::encryption::parse_kek_hex;
+    use boruna_orchestrator::audit::rotate::{
+        rotate_bundle, rotate_dir, RotateOptions, RotationOutcome,
+    };
+
+    let old_kek = parse_kek_hex(old_kek_hex).map_err(|e| format!("--old-kek: {e}"))?;
+    let new_kek = parse_kek_hex(new_kek_hex).map_err(|e| format!("--new-kek: {e}"))?;
+
+    let opts = RotateOptions {
+        old_kek,
+        new_kek,
+        kek_id_from,
+        kek_id_to,
+        dry_run,
+    };
+
+    let manifest_at_target = target.join("manifest.json");
+    let single_bundle = manifest_at_target.is_file();
+
+    if single_bundle {
+        let outcome = rotate_bundle(&target, &opts)
+            .map_err(|e| format!("rotate {}: {e}", target.display()))?;
+        report_outcome(&target, &outcome);
+        return Ok(());
+    }
+
+    // Batch mode: target is a parent of bundle directories.
+    let p = parallelism.unwrap_or_else(|| std::cmp::min(8, num_threads_default()));
+    let results = rotate_dir(&target, &opts, p)
+        .map_err(|e| format!("scan bundles in {}: {e}", target.display()))?;
+
+    let mut rotated = 0u64;
+    let mut planned = 0u64;
+    let mut skipped = 0u64;
+    let mut failed = 0u64;
+    for (path, res) in &results {
+        match res {
+            Ok(outcome) => {
+                report_outcome(path, outcome);
+                match outcome {
+                    RotationOutcome::Rotated { .. } => rotated += 1,
+                    RotationOutcome::PlannedDryRun { .. } => planned += 1,
+                    RotationOutcome::NotEncrypted => skipped += 1,
+                }
+            }
+            Err(e) => {
+                eprintln!("rotate {}: {e}", path.display());
+                failed += 1;
+            }
+        }
+    }
+    println!("summary: rotated={rotated} planned={planned} skipped={skipped} failed={failed}");
+    if failed > 0 {
+        return Err(format!("{failed} bundle(s) failed to rotate; see stderr").into());
+    }
+    Ok(())
+}
+
+fn report_outcome(
+    path: &std::path::Path,
+    outcome: &boruna_orchestrator::audit::rotate::RotationOutcome,
+) {
+    use boruna_orchestrator::audit::rotate::RotationOutcome;
+    match outcome {
+        RotationOutcome::Rotated { new_kek_id } => {
+            println!("rotated {} (kek_id -> {new_kek_id})", path.display());
+        }
+        RotationOutcome::PlannedDryRun { new_kek_id } => {
+            println!(
+                "would rotate {} (kek_id -> {new_kek_id}) [dry-run]",
+                path.display()
+            );
+        }
+        RotationOutcome::NotEncrypted => {
+            println!("skip {} (plaintext bundle)", path.display());
+        }
+    }
+}
+
+/// Default thread-count for rotate-kek's parallelism. Matches the
+/// `min(8, num_cpus)` default the plan specifies. We use
+/// `std::thread::available_parallelism` so we don't pull in
+/// `num_cpus` just for this.
+fn num_threads_default() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
 }
 
 /// Sprint `W3-B`. Sweep orphan content-addressed blobs from the

--- a/docs/guides/kek-rotation.md
+++ b/docs/guides/kek-rotation.md
@@ -1,0 +1,102 @@
+# KEK Rotation
+
+Sprint reference: post1-T-2.4.
+
+`boruna evidence rotate-kek` re-wraps the data-encryption-key (DEK)
+of one or more encrypted evidence bundles under a new
+key-encryption-key (KEK). The DEK itself is **not** changed — only
+the manifest's `wrapped_dek`, `wrapped_dek_nonce`, and `kek_id`
+fields. Every per-file AES-GCM authentication tag in the bundle
+remains valid because the keying material that produced those tags
+hasn't moved.
+
+## When to rotate
+
+- A KEK is suspected leaked or has been retired in your KMS.
+- A scheduled rotation policy (e.g. "rotate every 6 months").
+- Migrating bundles from a legacy `kek_id` to a new one.
+
+Compliance auditors typically only need to see *that* rotation
+happened — the bundle's `bundle_hash` updates because the manifest
+contents change, but the audit log inside the bundle is unchanged.
+
+## Single-bundle rotation
+
+```sh
+boruna evidence rotate-kek \
+  /path/to/<run-id> \
+  --old-kek $(printenv OLD_KEK_HEX) \
+  --new-kek $(printenv NEW_KEK_HEX) \
+  --kek-id-to "rotation-2026-q3"
+```
+
+The bundle's `manifest.json` is rewritten atomically (sibling tmp +
+rename). The rest of the bundle directory is untouched.
+
+## Batch rotation
+
+Point `--target` at a parent directory whose immediate
+subdirectories are bundles:
+
+```sh
+boruna evidence rotate-kek \
+  /var/lib/boruna/evidence \
+  --old-kek $OLD --new-kek $NEW \
+  --kek-id-to "rotation-2026-q3" \
+  --parallelism 4
+```
+
+Each bundle is processed in its own rayon task, bounded by
+`--parallelism` (default `min(8, num_cpus)`). Per-bundle failures
+do not abort the batch — already-rotated bundles stay rotated, and
+the failed bundle is reported on stderr. The CLI exits non-zero if
+any bundle failed.
+
+## Dry-run
+
+Always dry-run first on a representative bundle:
+
+```sh
+boruna evidence rotate-kek bundles/abc... \
+  --old-kek $OLD --new-kek $NEW --kek-id-to new-id \
+  --dry-run
+```
+
+Dry-run validates that the old KEK can unwrap, that the new KEK
+re-wraps cleanly, and prints the planned `kek_id` change. **No
+files are modified.**
+
+## kek_id_from filter
+
+Use `--kek-id-from <id>` to defend against accidental
+double-rotation in a mixed-state batch (some bundles already
+rotated, others not):
+
+```sh
+boruna evidence rotate-kek bundles/ \
+  --old-kek $OLD --new-kek $NEW \
+  --kek-id-from "rotation-2026-q2" \
+  --kek-id-to "rotation-2026-q3"
+```
+
+Bundles whose current `kek_id` does not match `--kek-id-from` are
+reported as failures (`bundle kek_id is 'X'; --kek-id-from is 'Y'`)
+without being modified.
+
+## Verifying after rotation
+
+```sh
+boruna evidence verify /path/to/<run-id> \
+  --bundle-encryption-key $NEW_KEK_HEX
+```
+
+Verifying with the **old** KEK after rotation MUST fail with
+`evidence.encryption_key_mismatch` — that's the regression the
+rotation tool's tests assert on.
+
+## Spec reference
+
+The 1.0 evidence-bundle reader contract already accommodates
+re-wrapping: per-file ciphertext stays valid because the DEK is
+unchanged. See `docs/spec/evidence-bundle-1.0.md`. No spec version
+bump is required for this feature.

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -42,6 +42,11 @@ boruna-bytecode = { path = "../crates/llmbc" }
 # orchestrator binary stays statically linked (per ADR 001's musl
 # requirement). Confirmed by the probe in the ADR sprint.
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+# post1-T-2.4: parallel KEK rotation across many bundles. Defaults
+# to a work-stealing thread pool sized to num_cpus; the rotation
+# CLI bounds it via `--parallelism N`. Default features pulled in
+# (the crate has no system deps).
+rayon = "1"
 
 # macOS-only: libc for fcntl(F_FULLFSYNC). Plain `fsync(2)` on Darwin
 # does NOT flush the drive's write cache to media — only F_FULLFSYNC

--- a/orchestrator/src/audit/encryption.rs
+++ b/orchestrator/src/audit/encryption.rs
@@ -227,6 +227,49 @@ impl Envelope {
             .expect("AES-GCM encrypt should not fail on bounded input")
     }
 
+    /// Re-wrap the DEK held by this envelope under a new KEK + new
+    /// `kek_id` (post1-T-2.4 KEK rotation).
+    ///
+    /// The DEK itself is unchanged, so per-file AES-GCM tags inside
+    /// the bundle remain valid — only the manifest's `wrapped_dek`,
+    /// `wrapped_dek_nonce`, and `kek_id` fields change. A fresh
+    /// random `wrap_nonce` is used for the new wrap.
+    ///
+    /// Returns a new envelope with the same DEK and a new
+    /// `EncryptionInfo`. The `files` list is preserved verbatim.
+    pub fn rewrap(
+        &self,
+        new_kek: &[u8; KEY_LEN],
+        new_kek_id: &str,
+    ) -> Result<Envelope, EncryptionError> {
+        let mut wrap_nonce = [0u8; NONCE_LEN];
+        OsRng.fill_bytes(&mut wrap_nonce);
+
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(new_kek));
+        let wrapped = cipher
+            .encrypt(
+                Nonce::from_slice(&wrap_nonce),
+                Payload {
+                    msg: &self.dek,
+                    aad: new_kek_id.as_bytes(),
+                },
+            )
+            .map_err(|_| EncryptionError::CipherTagInvalid {
+                file: "<dek-rewrap>".to_string(),
+            })?;
+
+        Ok(Envelope {
+            dek: self.dek,
+            info: EncryptionInfo {
+                algorithm: ALGORITHM.to_string(),
+                kek_id: new_kek_id.to_string(),
+                wrapped_dek: B64.encode(&wrapped),
+                wrapped_dek_nonce: B64.encode(wrap_nonce),
+                files: self.info.files.clone(),
+            },
+        })
+    }
+
     /// Decrypt `ciphertext` for the given filename. Tag failures →
     /// `CipherTagInvalid`.
     pub fn decrypt_file(

--- a/orchestrator/src/audit/mod.rs
+++ b/orchestrator/src/audit/mod.rs
@@ -2,6 +2,7 @@ pub mod encryption;
 pub mod evidence;
 pub mod fingerprint;
 pub mod log;
+pub mod rotate;
 pub mod storage;
 pub mod verify;
 

--- a/orchestrator/src/audit/rotate.rs
+++ b/orchestrator/src/audit/rotate.rs
@@ -1,0 +1,449 @@
+//! KEK rotation tooling for evidence bundles (post1-T-2.4).
+//!
+//! Rotation is a manifest-only operation: the DEK is unwrapped with
+//! the old KEK, re-wrapped under the new KEK, and the manifest is
+//! atomically rewritten with the new wrapping. The bundle's
+//! ciphertext files are NOT touched — per-file AES-GCM tags depend
+//! on the DEK, which is unchanged.
+//!
+//! The single-bundle path is [`rotate_bundle`]; the directory-of-
+//! bundles parallel path is [`rotate_dir`].
+//!
+//! ## Atomicity
+//!
+//! Per-bundle: read manifest → unwrap → rewrap → write to
+//! `manifest.new.json` (sibling) → rename to `manifest.json`. A
+//! crash between rename'd manifests on different bundles leaves the
+//! already-rotated bundles fully rotated and the remaining bundles
+//! unchanged — no half-rotated states.
+
+use std::path::{Path, PathBuf};
+
+use rayon::prelude::*;
+
+use crate::audit::encryption::{EncryptionError, Envelope, KEY_LEN};
+use crate::audit::evidence::BundleManifest;
+
+/// Outcome of a single-bundle rotation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RotationOutcome {
+    /// Manifest rewritten with the new wrapping. Carries the new
+    /// `kek_id` for operator-facing reporting.
+    Rotated { new_kek_id: String },
+    /// `--dry-run`: nothing was written.
+    PlannedDryRun { new_kek_id: String },
+    /// Bundle is plaintext (no `encryption` block) — nothing to do.
+    /// Reported rather than skipped silently so the operator can
+    /// see the count in batch mode.
+    NotEncrypted,
+}
+
+#[derive(Debug)]
+pub enum RotationError {
+    Io(std::io::Error),
+    InvalidManifest(String),
+    Encryption(EncryptionError),
+    /// The bundle's `kek_id` doesn't match `--kek-id-from`. When the
+    /// operator supplies a `kek_id_from` filter (e.g. they rotated
+    /// in a prior pass) we MUST refuse rather than silently skip.
+    KekIdMismatch {
+        expected: String,
+        found: String,
+    },
+}
+
+impl std::fmt::Display for RotationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RotationError::Io(e) => write!(f, "io: {e}"),
+            RotationError::InvalidManifest(s) => write!(f, "invalid manifest: {s}"),
+            RotationError::Encryption(e) => write!(f, "encryption: {e}"),
+            RotationError::KekIdMismatch { expected, found } => write!(
+                f,
+                "bundle kek_id is '{found}'; --kek-id-from is '{expected}'"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RotationError {}
+
+impl From<std::io::Error> for RotationError {
+    fn from(e: std::io::Error) -> Self {
+        RotationError::Io(e)
+    }
+}
+
+impl From<EncryptionError> for RotationError {
+    fn from(e: EncryptionError) -> Self {
+        RotationError::Encryption(e)
+    }
+}
+
+/// Options for a rotation operation.
+#[derive(Debug, Clone)]
+pub struct RotateOptions {
+    pub old_kek: [u8; KEY_LEN],
+    pub new_kek: [u8; KEY_LEN],
+    /// When `Some`, only rotate bundles whose current `kek_id`
+    /// equals this value. Defends against accidental double-rotation.
+    pub kek_id_from: Option<String>,
+    /// New `kek_id` to write into the manifest.
+    pub kek_id_to: String,
+    /// When `true`, validate the rotation but do not write anything
+    /// to disk.
+    pub dry_run: bool,
+}
+
+/// Rotate the manifest of a single bundle directory.
+///
+/// `bundle_dir` is the path that contains `manifest.json`. The
+/// manifest is read, the DEK is unwrapped with `opts.old_kek`,
+/// re-wrapped under `opts.new_kek`/`opts.kek_id_to`, and the
+/// manifest is atomically rewritten unless `dry_run`.
+pub fn rotate_bundle(
+    bundle_dir: &Path,
+    opts: &RotateOptions,
+) -> Result<RotationOutcome, RotationError> {
+    let manifest_path = bundle_dir.join("manifest.json");
+    let raw = std::fs::read(&manifest_path)?;
+    let mut manifest: BundleManifest = serde_json::from_slice(&raw)
+        .map_err(|e| RotationError::InvalidManifest(format!("parse: {e}")))?;
+
+    let Some(info) = manifest.encryption.clone() else {
+        return Ok(RotationOutcome::NotEncrypted);
+    };
+
+    if let Some(expected) = &opts.kek_id_from {
+        if &info.kek_id != expected {
+            return Err(RotationError::KekIdMismatch {
+                expected: expected.clone(),
+                found: info.kek_id.clone(),
+            });
+        }
+    }
+
+    // Unwrap with old KEK.
+    let envelope = Envelope::unwrap(&info, &opts.old_kek)?;
+    // Re-wrap under new KEK.
+    let rewrapped = envelope.rewrap(&opts.new_kek, &opts.kek_id_to)?;
+    let new_info = rewrapped.info;
+
+    if opts.dry_run {
+        return Ok(RotationOutcome::PlannedDryRun {
+            new_kek_id: new_info.kek_id,
+        });
+    }
+
+    // Update manifest with the new encryption block + recomputed
+    // bundle_hash. The bundle_hash is sha256 of the
+    // pretty-printed manifest with bundle_hash itself zeroed,
+    // matching the build-time computation in
+    // `EvidenceBundleBuilder::finalize`.
+    manifest.encryption = Some(new_info.clone());
+    let new_bundle_hash = compute_bundle_hash(&manifest)?;
+    manifest.bundle_hash = new_bundle_hash;
+
+    let final_json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| RotationError::InvalidManifest(format!("re-serialize: {e}")))?;
+
+    // Atomic write: sibling tmp + rename. Use a per-process tmp
+    // suffix (project §38) so concurrent rotations on the same
+    // bundle (shouldn't happen, but defense in depth) don't collide.
+    let pid = std::process::id();
+    let tmp = bundle_dir.join(format!("manifest.tmp.{pid}.json"));
+    std::fs::write(&tmp, final_json.as_bytes())?;
+    std::fs::rename(&tmp, &manifest_path)?;
+
+    Ok(RotationOutcome::Rotated {
+        new_kek_id: new_info.kek_id,
+    })
+}
+
+/// Rotate every bundle directory under `parent`. Each immediate
+/// subdirectory containing a `manifest.json` is treated as a bundle.
+/// Rotation runs in parallel via rayon, bounded by `parallelism`.
+///
+/// On success returns one `(bundle_dir, outcome)` per bundle, in
+/// path order. On per-bundle failure, the failing entry returns
+/// `Err`; already-rotated bundles stay rotated. The outer `Result`
+/// only fails if listing `parent` fails.
+pub fn rotate_dir(
+    parent: &Path,
+    opts: &RotateOptions,
+    parallelism: usize,
+) -> std::io::Result<Vec<(PathBuf, Result<RotationOutcome, RotationError>)>> {
+    let mut bundles: Vec<PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(parent)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        if path.join("manifest.json").is_file() {
+            bundles.push(path);
+        }
+    }
+    bundles.sort();
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(parallelism.max(1))
+        .build()
+        .map_err(std::io::Error::other)?;
+
+    let results: Vec<(PathBuf, Result<RotationOutcome, RotationError>)> = pool.install(|| {
+        bundles
+            .par_iter()
+            .map(|bundle_dir| {
+                let outcome = rotate_bundle(bundle_dir, opts);
+                (bundle_dir.clone(), outcome)
+            })
+            .collect()
+    });
+
+    Ok(results)
+}
+
+/// Compute the bundle hash exactly the way `EvidenceBundleBuilder::finalize`
+/// does at build time: pretty-print the manifest with its
+/// `bundle_hash` field reset to empty, then sha256 the result.
+fn compute_bundle_hash(manifest: &BundleManifest) -> Result<String, RotationError> {
+    let mut clone = manifest.clone();
+    clone.bundle_hash = String::new();
+    let json = serde_json::to_string_pretty(&clone)
+        .map_err(|e| RotationError::InvalidManifest(format!("hash-prep: {e}")))?;
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(json.as_bytes());
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::evidence::EvidenceBundleBuilder;
+    use crate::audit::log::{AuditEvent, AuditLog};
+    use crate::audit::verify::verify_bundle_with_kek;
+
+    fn make_kek(seed: u8) -> [u8; KEY_LEN] {
+        let mut k = [0u8; KEY_LEN];
+        for (i, b) in k.iter_mut().enumerate() {
+            *b = seed.wrapping_add(i as u8);
+        }
+        k
+    }
+
+    fn build_encrypted_bundle(
+        dir: &Path,
+        run_id: &str,
+        kek: &[u8; KEY_LEN],
+        kek_id: &str,
+    ) -> PathBuf {
+        let mut builder = EvidenceBundleBuilder::new(dir, run_id, "rotate-test").unwrap();
+        builder = builder.with_encryption(kek, kek_id).unwrap();
+        builder.add_workflow_def("{\"name\":\"x\"}").unwrap();
+        builder.add_policy("{}").unwrap();
+        let mut audit = AuditLog::new();
+        audit.append(AuditEvent::WorkflowStarted {
+            workflow_hash: "wf".into(),
+            policy_hash: "po".into(),
+        });
+        builder.finalize(&audit).unwrap();
+        dir.join(run_id)
+    }
+
+    #[test]
+    fn rotate_then_verify_with_new_kek() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = make_kek(1);
+        let new = make_kek(2);
+        let bundle = build_encrypted_bundle(dir.path(), "r-1", &old, "key-old");
+
+        let outcome = rotate_bundle(
+            &bundle,
+            &RotateOptions {
+                old_kek: old,
+                new_kek: new,
+                kek_id_from: None,
+                kek_id_to: "key-new".into(),
+                dry_run: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            outcome,
+            RotationOutcome::Rotated {
+                new_kek_id: "key-new".into()
+            }
+        );
+
+        // Verify with NEW kek succeeds.
+        let report = verify_bundle_with_kek(&bundle, Some(&new));
+        assert!(report.valid, "report: {report:?}");
+
+        // Verify with OLD kek fails (key mismatch).
+        let report = verify_bundle_with_kek(&bundle, Some(&old));
+        assert!(!report.valid, "old kek should not verify: {report:?}");
+    }
+
+    #[test]
+    fn dry_run_does_not_modify() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = make_kek(1);
+        let new = make_kek(2);
+        let bundle = build_encrypted_bundle(dir.path(), "r-2", &old, "key-old");
+
+        let manifest_before = std::fs::read(bundle.join("manifest.json")).unwrap();
+
+        let outcome = rotate_bundle(
+            &bundle,
+            &RotateOptions {
+                old_kek: old,
+                new_kek: new,
+                kek_id_from: None,
+                kek_id_to: "key-new".into(),
+                dry_run: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            outcome,
+            RotationOutcome::PlannedDryRun {
+                new_kek_id: "key-new".into()
+            }
+        );
+
+        let manifest_after = std::fs::read(bundle.join("manifest.json")).unwrap();
+        assert_eq!(
+            manifest_before, manifest_after,
+            "dry-run must not modify the manifest"
+        );
+
+        // Old KEK still works (rotation didn't happen).
+        let report = verify_bundle_with_kek(&bundle, Some(&old));
+        assert!(report.valid);
+    }
+
+    #[test]
+    fn kek_id_from_mismatch_rejects() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = make_kek(1);
+        let new = make_kek(2);
+        let bundle = build_encrypted_bundle(dir.path(), "r-3", &old, "key-old");
+
+        let err = rotate_bundle(
+            &bundle,
+            &RotateOptions {
+                old_kek: old,
+                new_kek: new,
+                kek_id_from: Some("key-different".into()),
+                kek_id_to: "key-new".into(),
+                dry_run: false,
+            },
+        )
+        .unwrap_err();
+        match err {
+            RotationError::KekIdMismatch { expected, found } => {
+                assert_eq!(expected, "key-different");
+                assert_eq!(found, "key-old");
+            }
+            other => panic!("expected KekIdMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rotate_dir_processes_only_bundle_subdirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = make_kek(1);
+        let new = make_kek(2);
+        build_encrypted_bundle(dir.path(), "r-a", &old, "key-old");
+        build_encrypted_bundle(dir.path(), "r-b", &old, "key-old");
+        // A non-bundle subdirectory is ignored (no manifest.json).
+        std::fs::create_dir_all(dir.path().join("not-a-bundle")).unwrap();
+        std::fs::write(dir.path().join("not-a-bundle").join("readme.txt"), b"x").unwrap();
+
+        let results = rotate_dir(
+            dir.path(),
+            &RotateOptions {
+                old_kek: old,
+                new_kek: new,
+                kek_id_from: None,
+                kek_id_to: "key-new".into(),
+                dry_run: false,
+            },
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 2, "should pick up r-a and r-b only");
+        for (_, outcome) in &results {
+            assert!(matches!(outcome, Ok(RotationOutcome::Rotated { .. })));
+        }
+    }
+
+    #[test]
+    fn rotate_dir_per_bundle_failure_does_not_abort_others() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = make_kek(1);
+        let new = make_kek(2);
+        build_encrypted_bundle(dir.path(), "good", &old, "key-old");
+        // A bundle whose manifest is corrupt — rotation should fail
+        // for it, but the good bundle should still rotate.
+        let bad = dir.path().join("bad");
+        std::fs::create_dir_all(&bad).unwrap();
+        std::fs::write(bad.join("manifest.json"), b"{not-json").unwrap();
+
+        let results = rotate_dir(
+            dir.path(),
+            &RotateOptions {
+                old_kek: old,
+                new_kek: new,
+                kek_id_from: None,
+                kek_id_to: "key-new".into(),
+                dry_run: false,
+            },
+            2,
+        )
+        .unwrap();
+
+        let by_name: std::collections::BTreeMap<_, _> = results
+            .into_iter()
+            .map(|(p, r)| (p.file_name().unwrap().to_string_lossy().to_string(), r))
+            .collect();
+        assert!(matches!(
+            by_name["good"],
+            Ok(RotationOutcome::Rotated { .. })
+        ));
+        assert!(by_name["bad"].is_err());
+    }
+
+    #[test]
+    fn plaintext_bundle_is_reported_not_rotated() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = make_kek(1);
+        let new = make_kek(2);
+        // Plaintext bundle (no `with_encryption`).
+        let mut builder = EvidenceBundleBuilder::new(dir.path(), "plain", "rotate-test").unwrap();
+        builder.add_workflow_def("{}").unwrap();
+        builder.add_policy("{}").unwrap();
+        let mut audit = AuditLog::new();
+        audit.append(AuditEvent::WorkflowStarted {
+            workflow_hash: "wf".into(),
+            policy_hash: "po".into(),
+        });
+        builder.finalize(&audit).unwrap();
+
+        let outcome = rotate_bundle(
+            &dir.path().join("plain"),
+            &RotateOptions {
+                old_kek: old,
+                new_kek: new,
+                kek_id_from: None,
+                kek_id_to: "key-new".into(),
+                dry_run: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome, RotationOutcome::NotEncrypted);
+    }
+}


### PR DESCRIPTION
## Summary

[T-2.4] of the post-1.0 execution plan. Operators can now rotate
the KEK on encrypted evidence bundles without re-encrypting any
ciphertext.

## Design assumptions

- **Manifest-only operation.** Per the plan, "the
  `evidence-bundle-1.0.md` reader contract already accommodates
  re-wrapping (DEK unchanged → tag invariant preserved)." The DEK
  is unwrapped with the old KEK, re-wrapped with the new KEK, and
  written into the same manifest. Per-file ciphertext is not
  re-encrypted because every per-file AES-GCM tag was bound to
  the DEK, not the KEK.
- **`bundle_hash` does change.** The encryption block's
  `wrapped_dek` and `wrapped_dek_nonce` participate in the
  bundle_hash, so the manifest's hash must be recomputed. The
  rewriter mirrors `EvidenceBundleBuilder::finalize`'s hashing
  (sha256 of pretty-printed manifest with `bundle_hash` zeroed).
  This is intentional: an auditor sees the bundle was rotated
  via the new bundle_hash, while still being able to verify
  every step's output against unchanged file hashes.
- **No spec version bump.** The plan calls this out explicitly;
  added a clarifying note to `docs/guides/kek-rotation.md`.
- **Rayon for batch parallelism.** New workspace dep, minimal
  surface — bounded thread pool + `par_iter` only.
- **Per-process tmp suffix** on the manifest tmp file (project
  §38) so concurrent rotations on the same bundle don't race.
  Real-world callers shouldn't run two rotations on one bundle,
  but defense in depth is cheap here.

## Acceptance criteria

- [x] Test: rotate a bundle, verify with new KEK, fail with old
  KEK. (`rotate_then_verify_with_new_kek`)
- [x] Test: dry-run does not modify anything.
  (`dry_run_does_not_modify`)
- [x] Test: mid-batch failure leaves consistent on-disk state.
  (`rotate_dir_per_bundle_failure_does_not_abort_others` — good
  bundles rotated, bad ones reported as Err.)
- [x] `docs/guides/kek-rotation.md` written.
- [x] CHANGELOG entry under "Added".

## Local gates

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` — clean (6 new rotate tests + all
  prior tests).
- [ ] `cargo bench --no-run --workspace` — relies on CI's existing
  "Compile benches (no-run)" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)