### PR TITLE
feat(post1-T-4.2): mTLS CRL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added (0.7.x speculative)
+
+- `boruna coordinator serve --tls-client-crl <FILE>` (post1-T-4.2)
+  loads PEM-encoded X509 CRLs at startup and feeds them to
+  rustls's `WebPkiClientVerifier::with_crls`. Connections from
+  revoked client certs are rejected at handshake. Multiple CRLs
+  supported via repeated flag (one per intermediate CA). CRL
+  parse failure on startup is a fatal startup error; CRLs without
+  the mTLS trio are a fatal startup error. Reload-on-SIGHUP is
+  the documented intent but not in this PR — see
+  `docs/guides/mtls-crl.md`. **0.7.x-only** feature: not part of
+  the 1.x LTS surface.
+
 ## [1.0.0] - 2026-04-28
 
 **First stable release.** The 1.x LTS contract takes effect from

--- a/crates/llmvm-cli/src/coordinator.rs
+++ b/crates/llmvm-cli/src/coordinator.rs
@@ -140,6 +140,17 @@ pub struct ServerTlsPaths {
     pub cert: PathBuf,
     pub key: PathBuf,
     pub client_ca: PathBuf,
+    /// post1-T-4.2 (0.7.x): optional list of CRL files to revoke
+    /// previously-trusted client certificates without redistributing
+    /// the CA bundle. Each CRL is loaded as a PEM-encoded
+    /// `X509 CRL` blob and passed to
+    /// `WebPkiClientVerifier::with_crls` at server-config build
+    /// time. Multiple CRLs (one per intermediate CA) are supported
+    /// by passing the flag repeatedly. CRL parse failure on
+    /// startup is a typed startup error; reload behavior on
+    /// SIGHUP is documented in
+    /// `docs/guides/mtls-crl.md`.
+    pub crls: Vec<PathBuf>,
 }
 
 impl ServerTlsPaths {
@@ -147,17 +158,32 @@ impl ServerTlsPaths {
     /// `None` (no TLS — pre-W6 behavior) or a fully-populated
     /// triple. Mixing-and-matching (e.g. `--tls-cert` without
     /// `--tls-key`) is a startup error per project §1.
+    ///
+    /// `crls` is independent — passing CRLs without the cert/key
+    /// trio is a startup error so misconfigured CRL paths don't
+    /// silently disappear into a plaintext-only server.
     pub fn from_optional(
         cert: Option<PathBuf>,
         key: Option<PathBuf>,
         client_ca: Option<PathBuf>,
+        crls: Vec<PathBuf>,
     ) -> Result<Option<Self>, Box<dyn std::error::Error>> {
         match (cert, key, client_ca) {
-            (None, None, None) => Ok(None),
+            (None, None, None) => {
+                if !crls.is_empty() {
+                    return Err(
+                        "--tls-client-crl requires --tls-cert/--tls-key/--tls-client-ca \
+                         to be configured (CRLs apply to mTLS only)"
+                            .into(),
+                    );
+                }
+                Ok(None)
+            }
             (Some(cert), Some(key), Some(client_ca)) => Ok(Some(Self {
                 cert,
                 key,
                 client_ca,
+                crls,
             })),
             _ => Err("--tls-cert, --tls-key, --tls-client-ca must all be provided together".into()),
         }
@@ -353,7 +379,15 @@ fn build_server_tls(
             .map_err(|e| format!("invalid client CA cert: {e}"))?;
     }
 
-    let verifier = WebPkiClientVerifier::builder(Arc::new(roots))
+    // post1-T-4.2: load CRLs and pass to the builder. CRL parse
+    // failure at startup is a fatal startup error — we refuse to
+    // come up with a half-configured revocation surface.
+    let crls = load_crls(&paths.crls)?;
+    let mut builder = WebPkiClientVerifier::builder(Arc::new(roots));
+    if !crls.is_empty() {
+        builder = builder.with_crls(crls);
+    }
+    let verifier = builder
         .build()
         .map_err(|e| format!("build client cert verifier: {e}"))?;
 
@@ -401,6 +435,39 @@ fn load_private_key(
         .map_err(|e| format!("parse key {}: {e}", path.display()))?
         .ok_or_else(|| format!("no private key found in {}", path.display()))?;
     Ok(key)
+}
+
+/// post1-T-4.2: load CRL files. Each file may contain one or more
+/// PEM-encoded `X509 CRL` blocks (most CAs emit one per file, but
+/// concatenations are accepted). Empty files and files with no
+/// CRL blocks are a typed startup error so misconfigured paths
+/// don't silently produce a CRL-less verifier.
+fn load_crls(
+    paths: &[std::path::PathBuf],
+) -> Result<Vec<rustls::pki_types::CertificateRevocationListDer<'static>>, Box<dyn std::error::Error>>
+{
+    let mut out = Vec::new();
+    for path in paths {
+        let pem = std::fs::read(path).map_err(|e| format!("read CRL {}: {e}", path.display()))?;
+        let mut reader = std::io::Cursor::new(pem);
+        let mut count_in_file = 0usize;
+        for entry in rustls_pemfile::crls(&mut reader) {
+            let crl = entry.map_err(|e| format!("parse CRL block in {}: {e}", path.display()))?;
+            out.push(crl);
+            count_in_file += 1;
+        }
+        if count_in_file == 0 {
+            return Err(format!(
+                "no `X509 CRL` PEM blocks found in {} — \
+                 expected at least one. (Hint: \
+                 `openssl crl -inform DER -in <file>.crl -out <file>.pem` \
+                 converts a DER CRL to PEM.)",
+                path.display()
+            )
+            .into());
+        }
+    }
+    Ok(out)
 }
 
 /// Per-connection TLS accept loop. Wraps each accepted TCP stream
@@ -3651,14 +3718,18 @@ mod tests {
     #[test]
     fn parse_tls_flags_requires_all_three_or_none() {
         // None of the three flags = no TLS, ok.
-        assert!(ServerTlsPaths::from_optional(None, None, None)
+        assert!(ServerTlsPaths::from_optional(None, None, None, vec![])
             .unwrap()
             .is_none());
         // All three present = ok.
         let p = std::path::PathBuf::from("/tmp/x");
-        let triple =
-            ServerTlsPaths::from_optional(Some(p.clone()), Some(p.clone()), Some(p.clone()))
-                .unwrap();
+        let triple = ServerTlsPaths::from_optional(
+            Some(p.clone()),
+            Some(p.clone()),
+            Some(p.clone()),
+            vec![],
+        )
+        .unwrap();
         assert!(triple.is_some());
         // Any partial combination is rejected.
         for (a, b, c) in [
@@ -3669,12 +3740,23 @@ mod tests {
             (Some(p.clone()), None, Some(p.clone())),
             (None, Some(p.clone()), Some(p.clone())),
         ] {
-            let err = ServerTlsPaths::from_optional(a, b, c).unwrap_err();
+            let err = ServerTlsPaths::from_optional(a, b, c, vec![]).unwrap_err();
             assert!(
                 err.to_string().contains("must all be provided together"),
                 "unexpected err: {err}"
             );
         }
+    }
+
+    #[test]
+    fn parse_tls_flags_crls_without_mtls_rejected() {
+        // post1-T-4.2: passing --tls-client-crl without the mTLS
+        // trio is a startup error. The CRL cannot apply to a
+        // plaintext server, so silently dropping it would be a
+        // dangerous footgun.
+        let crl = std::path::PathBuf::from("/tmp/some.crl");
+        let err = ServerTlsPaths::from_optional(None, None, None, vec![crl]).unwrap_err();
+        assert!(err.to_string().contains("CRL"), "unexpected err: {err}");
     }
 
     #[tokio::test]

--- a/crates/llmvm-cli/src/main.rs
+++ b/crates/llmvm-cli/src/main.rs
@@ -289,6 +289,19 @@ enum CoordinatorCommand {
         /// body — mismatch returns `coord.identity_mismatch`.
         #[arg(long)]
         tls_client_ca: Option<PathBuf>,
+        /// post1-T-4.2 (0.7.x): PEM-encoded X509 CRL file used
+        /// to revoke previously-trusted client certificates
+        /// without redistributing the CA bundle. Pass repeatedly
+        /// for multiple CRLs (one per intermediate CA).
+        ///
+        /// CRL parse failure on startup is a fatal error.
+        /// Reload-on-SIGHUP semantics are documented in
+        /// `docs/guides/mtls-crl.md`.
+        ///
+        /// Requires the full `--tls-cert/--tls-key/--tls-client-ca`
+        /// trio — passing CRLs without mTLS is a startup error.
+        #[arg(long, value_name = "FILE")]
+        tls_client_crl: Vec<PathBuf>,
     },
     /// Drive a submit-only workflow run to terminal status by
     /// computing downstream-ready successors as workers complete
@@ -1340,6 +1353,7 @@ fn run_coordinator(
             tls_cert,
             tls_key,
             tls_client_ca,
+            tls_client_crl,
         } => {
             #[cfg(feature = "persist-sqlite")]
             {
@@ -1347,8 +1361,12 @@ fn run_coordinator(
                 let bind_addr: std::net::IpAddr = bind
                     .parse()
                     .map_err(|e| format!("invalid --bind address {bind:?}: {e}"))?;
-                let tls_config =
-                    coordinator::ServerTlsPaths::from_optional(tls_cert, tls_key, tls_client_ca)?;
+                let tls_config = coordinator::ServerTlsPaths::from_optional(
+                    tls_cert,
+                    tls_key,
+                    tls_client_ca,
+                    tls_client_crl,
+                )?;
                 coordinator::run_serve(
                     resolved,
                     port,
@@ -1373,6 +1391,7 @@ fn run_coordinator(
                     tls_cert,
                     tls_key,
                     tls_client_ca,
+                    tls_client_crl,
                 );
                 return Err("`coordinator serve` requires the `persist-sqlite` feature".into());
             }

--- a/docs/guides/mtls-crl.md
+++ b/docs/guides/mtls-crl.md
@@ -1,0 +1,82 @@
+# mTLS Certificate Revocation Lists
+
+Sprint reference: post1-T-4.2 (0.7.x speculative branch).
+
+`boruna coordinator serve` accepts `--tls-client-crl <FILE>` to
+revoke previously-trusted client certificates without redistributing
+the CA bundle. The CRL is loaded at startup and consulted on every
+TLS handshake.
+
+> **0.7.x branch:** this feature lives on the parallel
+> `0.7.x` line and is **not** part of the 1.x LTS surface. Operators
+> running 1.x in production should pin to a 1.x tag; CRL support
+> arrives on `master` only after the 0.7.x design has stabilized
+> and a back-compat additive design is merged.
+
+## Configuration
+
+```sh
+boruna coordinator serve \
+  --tls-cert      /etc/boruna/tls/server.pem \
+  --tls-key       /etc/boruna/tls/server.key \
+  --tls-client-ca /etc/boruna/tls/clients-ca.pem \
+  --tls-client-crl /etc/boruna/tls/intermediate-a.crl.pem \
+  --tls-client-crl /etc/boruna/tls/intermediate-b.crl.pem
+```
+
+Pass `--tls-client-crl` repeatedly for multiple CRLs (one per
+intermediate CA). All listed files are loaded; their entries are
+merged into a single revocation set.
+
+CRL files MUST be PEM-encoded `X509 CRL`. If your CA emits DER:
+
+```sh
+openssl crl -inform DER -in cert.crl -out cert.crl.pem
+```
+
+## Failure modes
+
+- **CRL parse failure on startup** → fatal startup error. The
+  coordinator refuses to come up rather than silently fall through
+  to a CRL-less verifier.
+- **Empty CRL file** → fatal startup error (`no X509 CRL PEM blocks
+  found`). An empty file usually indicates a configuration mistake
+  rather than an intentional revocation reset.
+- **`--tls-client-crl` without `--tls-cert`/`--tls-key`/`--tls-client-ca`**
+  → fatal startup error. CRLs are meaningless on a plaintext server.
+- **Connection from a revoked cert** → TLS handshake rejected.
+  Clients see the standard `tls.cert_revoked` failure (rustls's
+  `BadCertificate(CertRevoked)`).
+
+## Reload on SIGHUP
+
+The mTLS handshake configuration is built from disk at process
+startup. To pick up CRL updates without a full restart, send the
+running process a `SIGHUP`. The signal handler re-reads every
+`--tls-client-crl` file and rebuilds the verifier.
+
+CRL parse failure on reload **does not** crash the process — the
+previous CRL set stays in effect, and the failure is logged with
+the offending path. This matches the standard "fail-static" model:
+a malformed CRL during reload should not blow away revocation
+that was already in force.
+
+> **Implementation status:** the SIGHUP reload path is part of the
+> 0.7.x design but is not in this PR. The current implementation
+> requires a process restart to pick up CRL changes. Tracked as a
+> follow-up; reload semantics above describe the intended
+> behavior.
+
+## Verification recipe (manual)
+
+After deploying, exercise the revocation path with a smoke test:
+
+1. Issue a client cert from your CA, register the worker, run a job.
+2. Add the cert's serial to the CRL, regenerate the PEM CRL.
+3. (Restart or SIGHUP the coord; depends on implementation status.)
+4. Re-attempt to register from the same client. The TLS handshake
+   should be rejected.
+5. Issue a fresh cert from the same CA. Register. Job runs.
+
+The first three steps cover the revocation path; the last two cover
+that revocation didn't accidentally lock out the CA itself.


### PR DESCRIPTION
## Summary

[T-4.2] of the post-1.0 execution plan, **landing on the `0.7.x`
speculative branch** (not `master`). Adds CRL support to the
mTLS-enabled coordinator so previously-trusted client certs can be
revoked without redistributing the CA bundle.

## Design assumptions

- **`paths = false → CRLs = false` is a startup error.** Passing
  `--tls-client-crl` without the full `--tls-cert/--tls-key/
  --tls-client-ca` trio is fatal at parse time. CRLs are
  meaningless on a plaintext server, and silently dropping the
  flag would mask a config mistake.
- **CRL parse failure at startup is fatal.** No half-configured
  revocation surface — if the CA bundle is loaded but the CRL
  isn't, an attacker holding a revoked cert would still get in.
- **Reload-on-SIGHUP is documented but not implemented in this
  PR.** The intent is to re-read the CRL files and rebuild the
  verifier on signal, with reload-time parse failures keeping the
  prior CRL set in force ("fail-static"). Tracked as a follow-up
  on the same branch; the docs mark the gap explicitly.
- **`#[arg(long)] tls_client_crl: Vec<PathBuf>`** is the clap
  pattern for "pass repeatedly." Each occurrence appends one file.
- **0.7.x branch only.** The plan classifies T-4.2 as
  speculative because the rustls API surface (CRL handling,
  reload story) is still maturing. We're shipping it here so
  operators on the 0.7.x line can exercise it; a 1.x-compatible
  additive landing happens later if/when the design holds up.

## Acceptance criteria

- [x] Integration test path exists: `parse_tls_flags_crls_without_mtls_rejected`
  covers the "CRL without mTLS trio" error. Manual cert/CRL
  generation + handshake rejection is documented in
  `docs/guides/mtls-crl.md` (rcgen test fixtures for revoked
  cert handshake rejection are a follow-up).
- [x] `docs/guides/mtls-crl.md` written.

## Local gates

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --features boruna-cli/serve --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` — clean (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)