### PR TITLE
feat(post1-T-3.1): S3 BundleStorage adapter behind `s3` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **S3 adapter for `BundleStorage`** (post1-T-3.1, Wave 3). The
+  `--bundle-storage s3://bucket[/prefix]` URI now constructs a real
+  remote-storage adapter when the binary is built with the `s3`
+  feature (`cargo build --features boruna-cli/s3`). Backed by the
+  Apache Arrow `object_store` crate's `aws` feature — works against
+  AWS S3, MinIO, Cloudflare R2, Backblaze B2, and LocalStack via
+  the standard `AWS_*` environment variables (including
+  `AWS_ENDPOINT_URL` for non-AWS endpoints). The adapter bridges
+  the sync `BundleStorage` trait against the async SDK with a
+  per-instance current-thread tokio runtime; bundle reads
+  materialize into a local cache directory rooted at
+  `BORUNA_BUNDLE_CACHE` (defaults to `<temp>/boruna-bundle-cache`).
+  When the `s3` feature is OFF, `s3://` URIs reject at parse time
+  with an actionable message that points operators at the feature
+  flag — never silently ignored. `gs://` (T-3.2) and `azblob://`
+  (T-3.3) remain reserved for upcoming adapters. Backend errors
+  surface with stable `error_kind` strings (`s3.transient`,
+  `s3.permanent`, `s3.runtime`, `s3.unexpected_key`). MinIO-backed
+  integration tests live behind the `s3-it` feature and self-skip
+  when Docker is unreachable. See `docs/guides/bundle-storage-s3.md`.
 - `boruna evidence rotate-kek` (post1-T-2.4) re-wraps the DEK of one
   or more encrypted evidence bundles under a new KEK. Operations are
   manifest-only — per-file ciphertext stays valid because the DEK

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -280,6 +286,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
 ]
 
 [[package]]
@@ -392,7 +448,7 @@ dependencies = [
  "clap",
  "jsonschema",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -404,22 +460,28 @@ name = "boruna-orchestrator"
 version = "1.0.0"
 dependencies = [
  "aes-gcm",
- "base64",
+ "base64 0.22.1",
  "boruna-bytecode",
  "boruna-compiler",
  "boruna-effect",
  "boruna-vm",
  "chrono",
  "clap",
+ "futures",
  "libc",
+ "object_store",
  "rand_core 0.6.4",
  "rayon",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -626,6 +688,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -804,6 +877,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -847,6 +931,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1128,7 +1223,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1145,6 +1240,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1192,6 +1293,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1381,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1405,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1281,7 +1419,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1296,6 +1434,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1439,6 +1592,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1533,6 +1697,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1575,7 +1748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "bytecount",
  "email_address",
  "fancy-regex",
@@ -1726,6 +1899,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1886,6 +2069,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "hyper",
+ "itertools 0.13.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.8.6",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +2121,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -2017,6 +2236,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,7 +2272,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2152,6 +2396,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2324,6 +2578,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -2409,11 +2672,12 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2426,6 +2690,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2433,12 +2698,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -2464,13 +2731,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2542,6 +2809,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2873,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2924,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2697,6 +3020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +3040,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2769,6 +3134,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +3175,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2838,6 +3247,44 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -2896,10 +3343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2907,6 +3356,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -2993,6 +3452,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,7 +3486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -3194,7 +3668,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -3214,6 +3688,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3389,9 +3864,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3402,7 +3890,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -3445,6 +3933,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,6 +3956,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3694,7 +4204,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3725,7 +4235,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -3744,7 +4254,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -3759,6 +4269,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yasna"

--- a/crates/llmvm-cli/Cargo.toml
+++ b/crates/llmvm-cli/Cargo.toml
@@ -30,6 +30,11 @@ telemetry = ["boruna-vm/telemetry", "dep:tokio"]
 # store. On by default (matching boruna-orchestrator). Build with
 # `--no-default-features` to drop SQLite from the binary.
 persist-sqlite = ["boruna-orchestrator/persist-sqlite"]
+# post1-T-3.1: forwards to boruna-orchestrator's `s3` feature so
+# `--bundle-storage s3://...` constructs a real adapter instead of
+# rejecting at parse time. Off by default — pulls in object_store +
+# tokio + reqwest. See docs/guides/bundle-storage-s3.md.
+s3 = ["boruna-orchestrator/s3"]
 
 [dependencies]
 boruna-bytecode = { path = "../llmbc" }

--- a/crates/llmvm-cli/src/main.rs
+++ b/crates/llmvm-cli/src/main.rs
@@ -721,17 +721,20 @@ enum WorkflowCommand {
         /// full-source coverage.
         #[arg(long, value_name = "HEX")]
         expect_workflow_hash: Option<String>,
-        /// post1-T-2.3: copy the finalized evidence bundle to a
-        /// pluggable storage backend after the local write
+        /// post1-T-2.3 / T-3.1: copy the finalized evidence bundle
+        /// to a pluggable storage backend after the local write
         /// succeeds. URI scheme dispatches to the adapter:
         ///   `local:<root>` — copy the bundle into `<root>/<run-id>/`.
-        /// Remote schemes (`s3://`, `gs://`, `azblob://`) are
-        /// reserved for future Wave 3 adapters and currently reject
-        /// at parse time. Falls back to `BORUNA_BUNDLE_STORAGE`
-        /// env var. When neither is set, no copy is made (the
-        /// pre-T-2.3 behavior). A copy failure is logged but does
-        /// not fail the workflow — the local bundle is the
-        /// authoritative record.
+        ///   `s3://<bucket>[/<prefix>]` — upload to S3 / S3-compatible
+        ///   storage (MinIO, R2, etc.). Requires the `s3` build
+        ///   feature; auth via standard `AWS_*` env vars. See
+        ///   `docs/guides/bundle-storage-s3.md`.
+        /// `gs://` / `azblob://` schemes are reserved for T-3.2 /
+        /// T-3.3 and currently reject at parse time. Falls back to
+        /// `BORUNA_BUNDLE_STORAGE` env var. When neither is set, no
+        /// copy is made (the pre-T-2.3 behavior). A copy failure is
+        /// logged but does not fail the workflow — the local bundle
+        /// is the authoritative record.
         #[arg(long, value_name = "URI", env = "BORUNA_BUNDLE_STORAGE")]
         bundle_storage: Option<String>,
     },

--- a/docs/guides/bundle-storage-s3.md
+++ b/docs/guides/bundle-storage-s3.md
@@ -1,0 +1,227 @@
+# Bundle Storage on S3
+
+Sprint reference: post1-T-3.1.
+
+The `--bundle-storage s3://...` flag tells `boruna workflow run` to
+copy the finalized evidence bundle to an S3 bucket after the local
+write succeeds. The local bundle remains the authoritative record;
+the S3 copy is an additional durable destination that survives the
+local data directory being wiped.
+
+## Status
+
+- **Adapter shipped:** S3 (this guide). Works against AWS S3 and
+  S3-compatible endpoints (MinIO, Cloudflare R2, Backblaze B2,
+  LocalStack).
+- **Reserved schemes:** `gs://` (T-3.2, GCS) and `azblob://` (T-3.3,
+  Azure Blob) are rejected at parse time until those adapters ship.
+
+## Build with the `s3` feature
+
+The S3 adapter pulls in `object_store` + `tokio` + `reqwest`. To keep
+the default binary lean, the adapter is OFF by default. Enable it at
+build time:
+
+```sh
+# CLI binary (boruna)
+cargo build --release --features boruna-cli/s3
+
+# Direct orchestrator usage from another Rust crate
+[dependencies]
+boruna-orchestrator = { path = "...", features = ["s3"] }
+```
+
+When you build *without* the `s3` feature and pass
+`--bundle-storage s3://...`, the URI rejects at parse time with a
+message that points you at the feature flag. Crucially: it never
+silently ignores the flag and ships an audit gap.
+
+## Configuring auth
+
+`object_store::aws::AmazonS3Builder::from_env()` reads the standard
+AWS environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | IAM access key |
+| `AWS_SECRET_ACCESS_KEY` | IAM secret |
+| `AWS_SESSION_TOKEN` | STS session token (optional) |
+| `AWS_REGION` | Defaults to `us-east-1` if unset |
+| `AWS_ENDPOINT_URL` | Override for MinIO / R2 / LocalStack |
+| `AWS_ALLOW_HTTP` | Set to `true` for non-HTTPS endpoints (testing only) |
+
+For production AWS, prefer instance/role credentials (the SDK picks
+those up automatically when none of the env vars above are set).
+
+### Required IAM permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::your-bucket",
+        "arn:aws:s3:::your-bucket/*"
+      ]
+    }
+  ]
+}
+```
+
+`s3:DeleteObject` is reserved for a future `evidence prune` flow;
+the current adapter does not delete objects.
+
+## Usage
+
+### Per-run
+
+```sh
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=eu-west-1
+
+boruna workflow run examples/workflows/llm_code_review \
+  --policy allow-all \
+  --record \
+  --bundle-storage s3://my-audit-bucket/prod/llm-review
+```
+
+After the run finalizes locally, the CLI prints:
+
+```
+evidence bundle: ./data/evidence/<run-id>
+  bundle_hash: <hex>
+  audit_log_hash: <hex>
+  files: 12
+  storage_ref: s3://my-audit-bucket/prod/llm-review/<run-id>
+```
+
+### Via env var
+
+The flag falls back to `BORUNA_BUNDLE_STORAGE`, so operators
+typically set this once in their service environment:
+
+```sh
+export BORUNA_BUNDLE_STORAGE=s3://my-audit-bucket/prod
+```
+
+## URI shape
+
+| Pattern | Effect |
+|---|---|
+| `s3://bucket` | Objects land at `<run-id>/<file>` |
+| `s3://bucket/prefix` | Objects land at `prefix/<run-id>/<file>` |
+| `s3://bucket/a/b/c/` | Trailing slash normalized; same as `s3://bucket/a/b/c` |
+
+The `StorageRef` returned by `put` is `s3://bucket/prefix/<run-id>`.
+Treat it as opaque; only the dispatcher parses it.
+
+## Reading bundles back
+
+Once you have the `storage_ref`, use the orchestrator API to
+materialize the bundle into a local cache directory:
+
+```rust
+use boruna_orchestrator::audit::storage::{from_uri, StorageRef};
+
+let storage = from_uri(Some("s3://my-audit-bucket/prod"))?.unwrap();
+let local_dir = storage.get(&StorageRef("s3://my-audit-bucket/prod/<run-id>".into()))?;
+// local_dir is now under BORUNA_BUNDLE_CACHE (defaults to <temp>/boruna-bundle-cache)
+// and contains the same files the original run finalized locally.
+
+boruna_orchestrator::audit::verify_bundle(&local_dir)?;
+```
+
+The cache directory is overwritten on each `get`. There is no
+automatic GC; sweep it periodically with `find $BORUNA_BUNDLE_CACHE
+-mtime +N -delete` or similar.
+
+## Failure semantics
+
+| Condition | Behavior |
+|---|---|
+| `--bundle-storage` URI invalid | Run still completes; warning printed; `storage_ref` not recorded. |
+| S3 put fails (network / auth / quota) | Run still completes; warning printed; `storage_ref` not recorded. **The local bundle is the authoritative record.** |
+| `s3://` passed without `s3` feature | Run rejects at flag parse time with an actionable message. |
+
+A storage failure never masks a successful workflow. Conversely,
+operators who require S3 durability should monitor the warning
+output and re-run `evidence verify` against the local bundle to
+confirm it's still on disk.
+
+## Error taxonomy
+
+`StorageError::Backend { kind, msg }` uses these stable kinds for S3
+operations:
+
+| `kind` | Meaning | Retry? |
+|---|---|---|
+| `s3.transient` | Network blip, timeout, throttle | Yes — `object_store` already retries internally; bubbled up means retries exhausted. |
+| `s3.permanent` | Auth failure, NoSuchBucket, AccessDenied | No — operator config issue. |
+| `s3.runtime` | Could not build the tokio runtime backing the adapter | No — host issue. |
+| `s3.unexpected_key` | Object listed under the run prefix but doesn't match the expected path layout | No — investigate; possible bucket pollution. |
+
+`StorageError::NotFound(ref)` fires when `get` is called against a
+ref that has zero objects under its prefix.
+
+## Testing against MinIO locally
+
+```sh
+# Spin up MinIO
+docker run -p 9000:9000 -p 9001:9001 \
+  -e MINIO_ROOT_USER=minioadmin \
+  -e MINIO_ROOT_PASSWORD=minioadmin \
+  quay.io/minio/minio server /data --console-address ":9001"
+
+# Create a bucket via the console (http://localhost:9001) or mc
+mc alias set local http://localhost:9000 minioadmin minioadmin
+mc mb local/boruna-audit
+
+# Run boruna against it
+export AWS_ENDPOINT_URL=http://localhost:9000
+export AWS_ACCESS_KEY_ID=minioadmin
+export AWS_SECRET_ACCESS_KEY=minioadmin
+export AWS_REGION=us-east-1
+export AWS_ALLOW_HTTP=true
+
+boruna workflow run examples/workflows/llm_code_review \
+  --policy allow-all \
+  --record \
+  --bundle-storage s3://boruna-audit/local-test
+```
+
+The `--features s3-it` integration test under `orchestrator/tests/`
+runs the full round-trip against a testcontainers-managed MinIO
+container; see `orchestrator/tests/s3_integration.rs` for the
+canonical example.
+
+## Determinism contract
+
+`storage_ref` is operational metadata — it does not feed any
+audit-log hash or replay comparison. The bundle's
+`bundle_hash` / `audit_log_hash` come from the local manifest and
+are independent of where the bundle is also stored.
+
+## Limitations
+
+- No automatic bucket creation. The bucket must exist before you
+  point boruna at it. Failure to find the bucket surfaces as
+  `s3.permanent`.
+- No multipart-upload tuning knob. `object_store` picks reasonable
+  defaults (5 MB part size). Files smaller than that go via single
+  PUT; larger ones use multipart automatically.
+- The cache directory is shared across adapters — if you rotate
+  between two buckets that contain different bundles for the same
+  `run_id`, the cache content is whichever was fetched most
+  recently. Operators who care about cross-bucket consistency
+  should set `BORUNA_BUNDLE_CACHE` to a per-bucket directory.
+- No retention / lifecycle policy is configured on the bucket;
+  operators define this server-side via S3 lifecycle rules.

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -11,6 +11,23 @@ http = ["boruna-vm/http"]
 # that don't need persistence (boruna-mcp, boruna-pkg); on by default for
 # the orchestrator itself.
 persist-sqlite = ["dep:rusqlite"]
+# post1-T-3.1: S3 BundleStorage adapter. Pulls in object_store + a
+# tokio current_thread runtime to bridge the sync trait against the
+# async SDK. Off by default — only operators wiring
+# `--bundle-storage s3://...` pay the dep tree cost. See
+# docs/guides/bundle-storage-s3.md.
+s3 = ["dep:object_store", "dep:tokio", "dep:futures"]
+# post1-T-3.1: integration tests that spin up MinIO via
+# testcontainers. Requires Docker on the test host. The test file
+# self-skips with a clear message when Docker is absent so a missing
+# daemon is never a CI failure mode for local devs.
+s3-it = [
+    "s3",
+    "dep:testcontainers",
+    "dep:testcontainers-modules",
+    "dep:tokio",
+    "dep:reqwest",
+]
 
 [[bin]]
 name = "boruna-orch"
@@ -47,6 +64,24 @@ rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 # CLI bounds it via `--parallelism N`. Default features pulled in
 # (the crate has no system deps).
 rayon = "1"
+
+# post1-T-3.1: object_store backs the S3 BundleStorage adapter.
+# `default-features = false` per ADR 001 (musl-friendly); `aws`
+# feature pulls in just the S3 client, reqwest+rustls+tokio. Optional
+# so the dep tree only loads when an operator opts into the `s3`
+# feature. `tokio` (workspace-pinned full feature set) is also
+# optional + s3-only — sync trait uses a current_thread runtime to
+# bridge the async SDK. `futures` is needed to consume
+# object_store's listing stream.
+object_store = { version = "0.11", default-features = false, features = ["aws"], optional = true }
+tokio = { workspace = true, optional = true }
+futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
+testcontainers = { version = "0.23", features = ["blocking"], optional = true }
+testcontainers-modules = { version = "0.11", features = ["minio"], optional = true }
+# Test-only: hit MinIO's S3 endpoint to create the test bucket
+# before object_store puts at it. Reqwest is already in the dep
+# tree via object_store, so this adds nothing to the binary.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 
 # macOS-only: libc for fcntl(F_FULLFSYNC). Plain `fsync(2)` on Darwin
 # does NOT flush the drive's write cache to media — only F_FULLFSYNC

--- a/orchestrator/src/audit/mod.rs
+++ b/orchestrator/src/audit/mod.rs
@@ -4,6 +4,8 @@ pub mod fingerprint;
 pub mod log;
 pub mod rotate;
 pub mod storage;
+#[cfg(feature = "s3")]
+pub mod storage_s3;
 pub mod verify;
 
 pub use encryption::{

--- a/orchestrator/src/audit/storage.rs
+++ b/orchestrator/src/audit/storage.rs
@@ -185,12 +185,17 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
 }
 
 /// Parse a `--bundle-storage <uri>` value into a constructed
-/// [`BundleStorage`] adapter. Only the `local:` scheme is
-/// supported in this PR; remote schemes return
-/// `StorageError::InvalidUri` until the relevant Wave 3 adapter
-/// lands.
+/// [`BundleStorage`] adapter.
 ///
-/// `local:<root>` constructs a `LocalFs` rooted at `<root>`.
+/// Recognized schemes:
+/// - `local:<root>` — always available; constructs a [`LocalFs`].
+/// - `s3://<bucket>[/<prefix>]` — requires the `s3` feature
+///   (post1-T-3.1). Constructs an
+///   [`crate::audit::storage_s3::S3Bucket`] backed by `object_store`.
+/// - `gs://<bucket>[/<prefix>]` and `azblob://<container>[/<prefix>]`
+///   — reserved for T-3.2 / T-3.3; rejected with
+///   [`StorageError::InvalidUri`] until those adapters ship.
+///
 /// Empty / `None` URI returns `None` so callers can fall back to
 /// their existing local-only path.
 #[doc(hidden)]
@@ -208,13 +213,32 @@ pub fn from_uri(uri: Option<&str>) -> Result<Option<Box<dyn BundleStorage>>, Sto
         }
         return Ok(Some(Box::new(LocalFs::new(rest))));
     }
-    // Reserve the remote schemes so the error message is helpful
-    // when an operator points a 1.x cluster at a not-yet-shipped
-    // adapter.
-    if uri.starts_with("s3://") || uri.starts_with("gs://") || uri.starts_with("azblob://") {
+    #[cfg(feature = "s3")]
+    if uri.starts_with("s3://") {
+        let bucket = crate::audit::storage_s3::S3Bucket::from_uri(uri)?;
+        return Ok(Some(Box::new(bucket)));
+    }
+    // Reserve schemes for adapters not (yet) available in this build.
+    // When the `s3` feature is OFF, `s3://` falls through here too —
+    // the error message tells operators to enable the feature.
+    #[cfg(not(feature = "s3"))]
+    if uri.starts_with("s3://") {
+        return Err(StorageError::InvalidUri(format!(
+            "{uri} requires the `s3` feature; rebuild with \
+             `--features boruna-orchestrator/s3` (or \
+             `--features boruna-cli/s3` for the CLI binary)"
+        )));
+    }
+    if uri.starts_with("gs://") || uri.starts_with("azblob://") {
         return Err(StorageError::InvalidUri(format!(
             "{uri} is reserved for a future remote-storage adapter; \
-             this Boruna build only supports local:<path>"
+             this Boruna build only supports local:<path>\
+             {extra}",
+            extra = if cfg!(feature = "s3") {
+                " and s3://"
+            } else {
+                ""
+            }
         )));
     }
     Err(StorageError::InvalidUri(uri.to_string()))
@@ -329,8 +353,30 @@ mod tests {
 
     #[test]
     fn from_uri_remote_schemes_reserve_clear_error() {
-        for uri in ["s3://b/p", "gs://b/p", "azblob://c/p"] {
+        // gs:// / azblob:// are still unimplemented in this build
+        // regardless of features.
+        for uri in ["gs://b/p", "azblob://c/p"] {
             assert_invalid_uri(from_uri(Some(uri)));
+        }
+    }
+
+    /// When the `s3` feature is OFF, `s3://` URIs must reject with
+    /// `InvalidUri` whose message tells the operator how to enable
+    /// the feature. This is a critical UX guarantee — silently
+    /// shipping a binary that ignores `--bundle-storage s3://...`
+    /// would produce an audit gap.
+    #[cfg(not(feature = "s3"))]
+    #[test]
+    fn from_uri_s3_without_feature_rejects_with_actionable_message() {
+        match from_uri(Some("s3://bucket/prefix")) {
+            Err(StorageError::InvalidUri(msg)) => {
+                assert!(
+                    msg.contains("requires the `s3` feature"),
+                    "expected actionable message, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected InvalidUri, got {other:?}"),
+            Ok(_) => panic!("expected error, got Ok"),
         }
     }
 

--- a/orchestrator/src/audit/storage_s3.rs
+++ b/orchestrator/src/audit/storage_s3.rs
@@ -1,0 +1,658 @@
+//! S3 [`BundleStorage`] adapter (post1-T-3.1).
+//!
+//! Backed by the Apache Arrow `object_store` crate's `aws` feature,
+//! which gives us a battle-tested S3 client with built-in
+//! exponential-backoff retries, multipart uploads, and a unified
+//! abstraction we can reuse for T-3.2 (GCS) and T-3.3 (Azure Blob)
+//! by toggling additional features on the same crate.
+//!
+//! ## URI shape
+//!
+//! `s3://<bucket>[/<prefix>]`
+//!
+//! - `s3://my-bucket` — bucket with no key prefix; objects land at
+//!   `<run-id>/<file>`.
+//! - `s3://my-bucket/audit/prod` — bucket with a key prefix; objects
+//!   land at `audit/prod/<run-id>/<file>`. Trailing slashes are
+//!   normalized away.
+//!
+//! The `StorageRef` returned by [`put`] echoes the construction URI
+//! suffixed with the run id, e.g. `s3://my-bucket/audit/prod/<run-id>`.
+//! Callers treat the string as opaque; only the dispatcher parses it.
+//!
+//! ## Configuration
+//!
+//! Authentication and endpoint are sourced from the standard AWS
+//! environment variables via [`object_store::aws::AmazonS3Builder::from_env`]:
+//!
+//! - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
+//! - `AWS_REGION` (defaults to `us-east-1` when unset)
+//! - `AWS_ENDPOINT_URL` — point at MinIO/LocalStack/etc.
+//! - `AWS_ALLOW_HTTP=true` — required for non-HTTPS endpoints
+//!
+//! ## Sync trait, async SDK
+//!
+//! [`crate::audit::storage::BundleStorage`] is sync because every
+//! call site (CLI, orchestrator background thread) is sync. The S3
+//! SDK is async. We bridge with a single-threaded current-thread
+//! tokio runtime owned by the adapter; each `put`/`get`/`list` runs
+//! its async work via `Runtime::block_on`. This is well-defined
+//! because the adapter is constructed and used outside any larger
+//! tokio runtime — the CLI's only async runtime today is the one
+//! the dashboard's axum server creates, which never reaches this
+//! code path.
+//!
+//! ## Local cache
+//!
+//! `get` materializes the bundle on local disk under a cache root
+//! (env `BORUNA_BUNDLE_CACHE`, defaults to
+//! `<temp>/boruna-bundle-cache`) and returns the resulting directory
+//! path. Repeated `get`s for the same ref overwrite the cache
+//! contents (idempotent — bundle finalize is deterministic given
+//! inputs, so the bytes are identical). No GC; operators clear the
+//! cache directory on rotation.
+//!
+//! ## Determinism contract
+//!
+//! - Object listings are sorted before iteration so [`list`] returns
+//!   `Vec<StorageRef>` in stable order across runs.
+//! - Upload is best-effort idempotent: re-`put`-ing the same `run_id`
+//!   overwrites the existing objects (which should be byte-identical
+//!   given the determinism contract on bundle finalize).
+//! - `put` failures are logged at the call site; the local bundle
+//!   remains the authoritative record (see `storage.rs` doc).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::path::Path as OsPath;
+use object_store::{Error as OsError, ObjectStore, PutPayload};
+use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
+
+use super::storage::{BundleStorage, StorageError, StorageRef};
+
+/// Default cache root for materialized bundles. Operators override
+/// via `BORUNA_BUNDLE_CACHE`.
+const CACHE_ENV_VAR: &str = "BORUNA_BUNDLE_CACHE";
+const CACHE_DIR_NAME: &str = "boruna-bundle-cache";
+
+/// Parsed `s3://<bucket>[/<prefix>]` URI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct S3Uri {
+    bucket: String,
+    /// Key prefix WITHOUT trailing slash. Empty string means
+    /// objects live at the bucket root.
+    prefix: String,
+}
+
+impl S3Uri {
+    fn parse(uri: &str) -> Result<Self, StorageError> {
+        let rest = uri
+            .strip_prefix("s3://")
+            .ok_or_else(|| StorageError::InvalidUri(uri.to_string()))?;
+        if rest.is_empty() {
+            return Err(StorageError::InvalidUri(format!(
+                "s3 URI missing bucket name: {uri}"
+            )));
+        }
+        let (bucket, prefix) = match rest.split_once('/') {
+            Some((b, p)) => (b, p.trim_end_matches('/')),
+            None => (rest, ""),
+        };
+        if bucket.is_empty() {
+            return Err(StorageError::InvalidUri(format!(
+                "s3 URI missing bucket name: {uri}"
+            )));
+        }
+        // S3 bucket-name rules are looser than we need to enforce
+        // here; we just reject the obvious invalids that would let a
+        // typo through (whitespace, scheme delimiters, leading dot).
+        if bucket.chars().any(|c| c.is_whitespace() || c == ':') {
+            return Err(StorageError::InvalidUri(format!(
+                "s3 URI has invalid bucket name: {uri}"
+            )));
+        }
+        Ok(S3Uri {
+            bucket: bucket.to_string(),
+            prefix: prefix.to_string(),
+        })
+    }
+
+    /// Object-store path for an object whose run-relative key is
+    /// `key`. Joins prefix + run_id + key with `/` separators.
+    fn object_path(&self, run_id: &str, key: &str) -> OsPath {
+        // Normalize: `prefix` has no trailing slash; `key` has no
+        // leading slash (we walk dir entries that way).
+        let mut parts = Vec::with_capacity(3);
+        if !self.prefix.is_empty() {
+            parts.push(self.prefix.as_str());
+        }
+        parts.push(run_id);
+        if !key.is_empty() {
+            parts.push(key);
+        }
+        OsPath::from(parts.join("/"))
+    }
+
+    /// `s3://<bucket>/<prefix>` — used as the reference suffix for
+    /// listings and as the prefix `put` echoes back with `/<run_id>`
+    /// appended.
+    fn root_uri(&self) -> String {
+        if self.prefix.is_empty() {
+            format!("s3://{}", self.bucket)
+        } else {
+            format!("s3://{}/{}", self.bucket, self.prefix)
+        }
+    }
+}
+
+/// S3-backed [`BundleStorage`] implementation.
+pub struct S3Bucket {
+    uri: S3Uri,
+    store: Arc<AmazonS3>,
+    runtime: Arc<Runtime>,
+    cache_root: PathBuf,
+}
+
+impl S3Bucket {
+    /// Build an [`S3Bucket`] from a `s3://bucket[/prefix]` URI.
+    /// Auth + endpoint come from `AWS_*` environment variables; see
+    /// the module docs. Equivalent to
+    /// `S3BucketBuilder::new(uri).build()`.
+    pub fn from_uri(uri: &str) -> Result<Self, StorageError> {
+        S3BucketBuilder::new(uri).build()
+    }
+
+    /// Run an async block on this adapter's runtime.
+    fn block_on<F, T>(&self, f: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        self.runtime.block_on(f)
+    }
+}
+
+/// Builder for [`S3Bucket`] that lets callers (mostly tests) override
+/// the local materialization cache root.
+///
+/// Production callers use [`S3Bucket::from_uri`] which delegates to
+/// `S3BucketBuilder::new(uri).build()`. The cache root then comes from
+/// `BORUNA_BUNDLE_CACHE` or `<temp>/boruna-bundle-cache`.
+pub struct S3BucketBuilder {
+    uri: String,
+    cache_root: Option<PathBuf>,
+}
+
+impl S3BucketBuilder {
+    /// Start a builder against the given `s3://bucket[/prefix]` URI.
+    pub fn new(uri: impl Into<String>) -> Self {
+        S3BucketBuilder {
+            uri: uri.into(),
+            cache_root: None,
+        }
+    }
+
+    /// Override the cache root used to materialize bundles in
+    /// [`S3Bucket::get`]. Tests use this to point at a `tempdir()`
+    /// so each test sees a clean cache.
+    pub fn with_cache_root(mut self, root: PathBuf) -> Self {
+        self.cache_root = Some(root);
+        self
+    }
+
+    /// Build the [`S3Bucket`].
+    pub fn build(self) -> Result<S3Bucket, StorageError> {
+        let parsed = S3Uri::parse(&self.uri)?;
+        let cache_root = self.cache_root.unwrap_or_else(default_cache_root);
+        let store = AmazonS3Builder::from_env()
+            .with_bucket_name(&parsed.bucket)
+            .build()
+            .map_err(|e| classify_os_error(e, "construct"))?;
+        let runtime = RuntimeBuilder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| StorageError::Backend {
+                kind: "s3.runtime",
+                msg: format!("failed to build tokio runtime: {e}"),
+            })?;
+        Ok(S3Bucket {
+            uri: parsed,
+            store: Arc::new(store),
+            runtime: Arc::new(runtime),
+            cache_root,
+        })
+    }
+}
+
+impl BundleStorage for S3Bucket {
+    fn put(&self, run_id: &str, bundle_dir: &Path) -> Result<StorageRef, StorageError> {
+        if run_id.is_empty() {
+            return Err(StorageError::InvalidUri("empty run_id".into()));
+        }
+        if !bundle_dir.is_dir() {
+            return Err(StorageError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("bundle dir not found: {}", bundle_dir.display()),
+            )));
+        }
+        let files = walk_files(bundle_dir)?;
+        // Deterministic upload order. Helps reasoning about partial-
+        // failure recovery.
+        let mut sorted = files;
+        sorted.sort();
+        for relative in &sorted {
+            let abs = bundle_dir.join(relative);
+            let bytes = std::fs::read(&abs)?;
+            let key = relative.to_string_lossy().replace('\\', "/");
+            let target = self.uri.object_path(run_id, &key);
+            self.block_on(async {
+                self.store
+                    .put(&target, PutPayload::from(bytes))
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| classify_os_error(e, "put"))
+            })?;
+        }
+        Ok(StorageRef(format!("{}/{}", self.uri.root_uri(), run_id)))
+    }
+
+    fn get(&self, r: &StorageRef) -> Result<PathBuf, StorageError> {
+        let run_id = ref_to_run_id(&self.uri, r)?;
+        let cache_dir = self.cache_root.join(&run_id);
+        // Idempotent: clear and re-materialize. Bundle finalize is
+        // deterministic so the bytes are identical, but a partial
+        // previous fetch could leave stale files.
+        if cache_dir.exists() {
+            std::fs::remove_dir_all(&cache_dir)?;
+        }
+        std::fs::create_dir_all(&cache_dir)?;
+
+        let prefix = self.uri.object_path(&run_id, "");
+        let entries = self.block_on(async {
+            use futures::StreamExt;
+            let mut stream = self.store.list(Some(&prefix));
+            let mut out = Vec::new();
+            while let Some(meta) = stream.next().await {
+                let meta = meta.map_err(|e| classify_os_error(e, "list"))?;
+                out.push(meta.location);
+            }
+            Ok::<_, StorageError>(out)
+        })?;
+
+        if entries.is_empty() {
+            return Err(StorageError::NotFound(r.0.clone()));
+        }
+
+        // Strip the bucket-side prefix (`<prefix>/<run_id>/`) so we
+        // can recreate the directory layout under cache_dir.
+        let strip = {
+            let mut s = prefix.to_string();
+            if !s.ends_with('/') {
+                s.push('/');
+            }
+            s
+        };
+
+        for location in entries {
+            let s = location.to_string();
+            let rel = s
+                .strip_prefix(&strip)
+                .ok_or_else(|| StorageError::Backend {
+                    kind: "s3.unexpected_key",
+                    msg: format!("object outside expected prefix: {s}"),
+                })?;
+            let dest = cache_dir.join(rel);
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let bytes = self.block_on(async {
+                self.store
+                    .get(&location)
+                    .await
+                    .map_err(|e| classify_os_error(e, "get"))?
+                    .bytes()
+                    .await
+                    .map_err(|e| classify_os_error(e, "get"))
+            })?;
+            std::fs::write(&dest, &bytes)?;
+        }
+
+        Ok(cache_dir)
+    }
+
+    fn list(&self, prefix_filter: Option<&str>) -> Result<Vec<StorageRef>, StorageError> {
+        // To enumerate the "directory" level (one StorageRef per
+        // run_id), use list_with_delimiter against the configured
+        // prefix.
+        let scan_prefix = if self.uri.prefix.is_empty() {
+            None
+        } else {
+            Some(OsPath::from(self.uri.prefix.as_str()))
+        };
+        let result = self.block_on(async {
+            self.store
+                .list_with_delimiter(scan_prefix.as_ref())
+                .await
+                .map_err(|e| classify_os_error(e, "list"))
+        })?;
+
+        let strip = if self.uri.prefix.is_empty() {
+            String::new()
+        } else {
+            let mut s = self.uri.prefix.clone();
+            if !s.ends_with('/') {
+                s.push('/');
+            }
+            s
+        };
+
+        let mut refs = Vec::new();
+        for common in result.common_prefixes {
+            let s = common.to_string();
+            let id = if strip.is_empty() {
+                s.trim_end_matches('/').to_string()
+            } else {
+                match s.strip_prefix(&strip) {
+                    Some(r) => r.trim_end_matches('/').to_string(),
+                    None => continue,
+                }
+            };
+            if id.is_empty() {
+                continue;
+            }
+            if let Some(p) = prefix_filter {
+                if !id.starts_with(p) {
+                    continue;
+                }
+            }
+            refs.push(StorageRef(format!("{}/{}", self.uri.root_uri(), id)));
+        }
+        refs.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(refs)
+    }
+}
+
+/// Recursively collect file paths under `root`, returning paths
+/// relative to `root`. Skips symlinks (bundles are pure files+dirs,
+/// matching `LocalFs` behavior).
+fn walk_files(root: &Path) -> Result<Vec<PathBuf>, StorageError> {
+    fn walk(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), StorageError> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let ft = entry.file_type()?;
+            if ft.is_dir() {
+                walk(root, &path, out)?;
+            } else if ft.is_file() {
+                let rel = path.strip_prefix(root).map_err(|_| {
+                    StorageError::Io(std::io::Error::other(format!(
+                        "walk: path {} not under root",
+                        path.display()
+                    )))
+                })?;
+                out.push(rel.to_path_buf());
+            }
+        }
+        Ok(())
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out)?;
+    Ok(out)
+}
+
+/// Extract the run id from a [`StorageRef`] that this adapter
+/// previously emitted. Validates that the bucket+prefix match the
+/// adapter's configured root so an operator-provided ref aimed at
+/// the wrong bucket/prefix surfaces clearly instead of silently
+/// returning NotFound.
+fn ref_to_run_id(uri: &S3Uri, r: &StorageRef) -> Result<String, StorageError> {
+    let root = uri.root_uri();
+    let suffix = r
+        .0
+        .strip_prefix(&root)
+        .and_then(|s| s.strip_prefix('/'))
+        .ok_or_else(|| {
+            StorageError::InvalidUri(format!("ref {} does not match adapter root {}", r.0, root))
+        })?;
+    if suffix.is_empty() || suffix.contains('/') {
+        return Err(StorageError::InvalidUri(format!(
+            "ref {} is not a single run-id under {}",
+            r.0, root
+        )));
+    }
+    Ok(suffix.to_string())
+}
+
+/// Map an `object_store` error onto a stable [`StorageError`]
+/// variant. The `kind` strings are a stable error_kind taxonomy so
+/// integrators (and the CLI's warning printer) can branch on them.
+///
+/// Mapping:
+/// - `NotFound` → [`StorageError::NotFound`] (the dispatcher's
+///   intrinsic NotFound).
+/// - `Generic` / `Unauthenticated` / `PermissionDenied` →
+///   `s3.permanent` (operator config issue; retry won't help).
+/// - everything else (transient I/O, retries already exhausted) →
+///   `s3.transient`.
+///
+/// The `op` argument names the calling site for better diagnostics
+/// (e.g. `"put"`, `"get"`, `"list"`, `"construct"`).
+fn classify_os_error(e: OsError, op: &'static str) -> StorageError {
+    match &e {
+        OsError::NotFound { .. } => StorageError::NotFound(format!("{op}: {e}")),
+        OsError::PermissionDenied { .. } | OsError::Unauthenticated { .. } => {
+            StorageError::Backend {
+                kind: "s3.permanent",
+                msg: format!("{op}: {e}"),
+            }
+        }
+        _ => StorageError::Backend {
+            kind: "s3.transient",
+            msg: format!("{op}: {e}"),
+        },
+    }
+}
+
+fn default_cache_root() -> PathBuf {
+    resolve_cache_root(std::env::var(CACHE_ENV_VAR).ok(), std::env::temp_dir())
+}
+
+/// Pure helper: pick the cache root given a raw env-var value and a
+/// fallback temp-dir. Extracted from [`default_cache_root`] so the
+/// resolution logic can be tested without touching process-wide
+/// environment (which would race with cargo's parallel test runner —
+/// see project-conventions §6 anti-pattern).
+fn resolve_cache_root(env_value: Option<String>, temp_dir: PathBuf) -> PathBuf {
+    match env_value {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => temp_dir.join(CACHE_DIR_NAME),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn s3_uri_parse_bucket_only() {
+        let u = S3Uri::parse("s3://my-bucket").unwrap();
+        assert_eq!(u.bucket, "my-bucket");
+        assert_eq!(u.prefix, "");
+        assert_eq!(u.root_uri(), "s3://my-bucket");
+    }
+
+    #[test]
+    fn s3_uri_parse_bucket_and_prefix() {
+        let u = S3Uri::parse("s3://b/audit/prod").unwrap();
+        assert_eq!(u.bucket, "b");
+        assert_eq!(u.prefix, "audit/prod");
+        assert_eq!(u.root_uri(), "s3://b/audit/prod");
+    }
+
+    #[test]
+    fn s3_uri_parse_strips_trailing_slash_on_prefix() {
+        let u = S3Uri::parse("s3://b/audit/prod/").unwrap();
+        assert_eq!(u.prefix, "audit/prod");
+    }
+
+    #[test]
+    fn s3_uri_parse_rejects_missing_bucket() {
+        for bad in ["s3://", "s3:///prefix"] {
+            assert!(matches!(
+                S3Uri::parse(bad),
+                Err(StorageError::InvalidUri(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn s3_uri_parse_rejects_wrong_scheme() {
+        for bad in ["http://b/p", "local:foo", "s3:bucket/p"] {
+            assert!(matches!(
+                S3Uri::parse(bad),
+                Err(StorageError::InvalidUri(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn s3_uri_parse_rejects_invalid_bucket_chars() {
+        for bad in ["s3:// bad", "s3://bad bucket/p"] {
+            assert!(matches!(
+                S3Uri::parse(bad),
+                Err(StorageError::InvalidUri(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn object_path_concatenates_prefix_run_id_key() {
+        let u = S3Uri::parse("s3://b/audit/prod").unwrap();
+        let p = u.object_path("run-7", "steps/a.json");
+        assert_eq!(p.to_string(), "audit/prod/run-7/steps/a.json");
+    }
+
+    #[test]
+    fn object_path_skips_empty_prefix() {
+        let u = S3Uri::parse("s3://b").unwrap();
+        let p = u.object_path("run-7", "manifest.json");
+        assert_eq!(p.to_string(), "run-7/manifest.json");
+    }
+
+    #[test]
+    fn object_path_skips_empty_key() {
+        let u = S3Uri::parse("s3://b/audit").unwrap();
+        let p = u.object_path("run-7", "");
+        assert_eq!(p.to_string(), "audit/run-7");
+    }
+
+    #[test]
+    fn ref_to_run_id_extracts_suffix() {
+        let u = S3Uri::parse("s3://b/audit").unwrap();
+        let id = ref_to_run_id(&u, &StorageRef("s3://b/audit/run-7".into())).unwrap();
+        assert_eq!(id, "run-7");
+    }
+
+    #[test]
+    fn ref_to_run_id_rejects_mismatched_root() {
+        let u = S3Uri::parse("s3://b/audit").unwrap();
+        let err = ref_to_run_id(&u, &StorageRef("s3://other/audit/run-7".into())).unwrap_err();
+        assert!(matches!(err, StorageError::InvalidUri(_)));
+    }
+
+    #[test]
+    fn ref_to_run_id_rejects_nested_path() {
+        let u = S3Uri::parse("s3://b/audit").unwrap();
+        let err = ref_to_run_id(&u, &StorageRef("s3://b/audit/run-7/extra".into())).unwrap_err();
+        assert!(matches!(err, StorageError::InvalidUri(_)));
+    }
+
+    #[test]
+    fn ref_to_run_id_rejects_empty_suffix() {
+        let u = S3Uri::parse("s3://b/audit").unwrap();
+        let err = ref_to_run_id(&u, &StorageRef("s3://b/audit/".into())).unwrap_err();
+        assert!(matches!(err, StorageError::InvalidUri(_)));
+    }
+
+    #[test]
+    fn walk_files_collects_recursively() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"a").unwrap();
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub").join("b.txt"), b"b").unwrap();
+        let mut files = walk_files(dir.path()).unwrap();
+        files.sort();
+        assert_eq!(
+            files,
+            vec![PathBuf::from("a.txt"), PathBuf::from("sub").join("b.txt")]
+        );
+    }
+
+    #[test]
+    fn classify_os_error_maps_known_kinds() {
+        let nf = classify_os_error(
+            OsError::NotFound {
+                path: "x".into(),
+                source: "missing".into(),
+            },
+            "get",
+        );
+        assert!(matches!(nf, StorageError::NotFound(_)));
+
+        let perm = classify_os_error(
+            OsError::PermissionDenied {
+                path: "x".into(),
+                source: "denied".into(),
+            },
+            "put",
+        );
+        match perm {
+            StorageError::Backend { kind, .. } => assert_eq!(kind, "s3.permanent"),
+            other => panic!("expected Backend, got {other:?}"),
+        }
+
+        let unauth = classify_os_error(
+            OsError::Unauthenticated {
+                path: "x".into(),
+                source: "no creds".into(),
+            },
+            "list",
+        );
+        match unauth {
+            StorageError::Backend { kind, .. } => assert_eq!(kind, "s3.permanent"),
+            other => panic!("expected Backend, got {other:?}"),
+        }
+
+        let generic = classify_os_error(
+            OsError::Generic {
+                store: "s3",
+                source: "boom".into(),
+            },
+            "put",
+        );
+        match generic {
+            StorageError::Backend { kind, .. } => assert_eq!(kind, "s3.transient"),
+            other => panic!("expected Backend, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_cache_root_uses_env_when_set() {
+        let p = resolve_cache_root(Some("/tmp/custom-cache".into()), PathBuf::from("/ignored"));
+        assert_eq!(p, PathBuf::from("/tmp/custom-cache"));
+    }
+
+    #[test]
+    fn resolve_cache_root_falls_back_when_env_unset_or_empty() {
+        let temp = PathBuf::from("/tmpdir");
+        assert_eq!(
+            resolve_cache_root(None, temp.clone()),
+            temp.join(CACHE_DIR_NAME)
+        );
+        assert_eq!(
+            resolve_cache_root(Some(String::new()), temp.clone()),
+            temp.join(CACHE_DIR_NAME)
+        );
+    }
+}

--- a/orchestrator/tests/s3_integration.rs
+++ b/orchestrator/tests/s3_integration.rs
@@ -1,0 +1,263 @@
+//! S3 BundleStorage integration tests (post1-T-3.1).
+//!
+//! These tests spin up a real MinIO container via testcontainers
+//! and exercise the full `put → list → get` round-trip of the
+//! [`boruna_orchestrator::audit::storage_s3::S3Bucket`] adapter
+//! against it.
+//!
+//! ## Running locally
+//!
+//! ```text
+//! # Requires Docker daemon running on the host.
+//! cargo test -p boruna-orchestrator --features s3-it --test s3_integration -- --nocapture
+//! ```
+//!
+//! ## CI behavior
+//!
+//! The `s3-it` feature gate keeps these tests OFF by default. They
+//! are not in the standard `cargo test --workspace` rotation. The
+//! GitHub Actions self-hosted runner (Friday) has Docker available
+//! and can opt in via a follow-up workflow if we ever decide to
+//! gate releases on a real S3 round-trip; for now the unit tests
+//! against `S3Uri::parse`, `object_path`, `ref_to_run_id`, and
+//! `classify_os_error` cover the determinism-relevant logic.
+//!
+//! ## Docker absence
+//!
+//! Each test self-skips with `eprintln!` + early-return when
+//! `testcontainers` cannot reach the Docker daemon, so a developer
+//! who enables `s3-it` without Docker installed sees a clear skip
+//! message instead of an opaque failure. This deliberately does
+//! NOT fail the test — Docker availability is an environment
+//! concern, not a regression signal.
+
+#![cfg(feature = "s3-it")]
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use boruna_orchestrator::audit::storage::{BundleStorage, StorageRef};
+use boruna_orchestrator::audit::storage_s3::S3BucketBuilder;
+use testcontainers::core::IntoContainerPort;
+use testcontainers::runners::SyncRunner;
+use testcontainers::Container;
+use testcontainers_modules::minio::MinIO;
+
+/// MinIO's API port. Mapped to a random host port by Docker.
+const MINIO_PORT: u16 = 9000;
+
+/// Default MinIO root credentials when no MINIO_ROOT_USER /
+/// MINIO_ROOT_PASSWORD env vars are passed to the container.
+const MINIO_USER: &str = "minioadmin";
+const MINIO_PASSWORD: &str = "minioadmin";
+
+/// Spin up a MinIO container. Returns None when Docker is
+/// unreachable so the test can skip with a clear message.
+fn try_start_minio() -> Option<Container<MinIO>> {
+    match MinIO::default().start() {
+        Ok(c) => Some(c),
+        Err(e) => {
+            eprintln!(
+                "skipping s3 integration test: could not start MinIO container ({e}); \
+                 ensure Docker is running on the host"
+            );
+            None
+        }
+    }
+}
+
+/// Wire up the AWS_* env vars object_store reads via
+/// `AmazonS3Builder::from_env`. Tests run sequentially within this
+/// file (separate processes from other test binaries) so the global
+/// env mutation is acceptable in this narrow scope. We restore
+/// nothing after the test — the process exits.
+fn set_aws_env(host: &str, port: u16) {
+    let endpoint = format!("http://{host}:{port}");
+    // SAFETY: cargo runs each integration-test binary in its own
+    // process and these tests are serialized via `INIT`. No other
+    // code in this binary reads AWS_* during construction.
+    unsafe {
+        std::env::set_var("AWS_ENDPOINT_URL", &endpoint);
+        std::env::set_var("AWS_ACCESS_KEY_ID", MINIO_USER);
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", MINIO_PASSWORD);
+        std::env::set_var("AWS_REGION", "us-east-1");
+        std::env::set_var("AWS_ALLOW_HTTP", "true");
+    }
+}
+
+/// Create the test bucket in MinIO using a one-off object_store
+/// client. We can't rely on auto-bucket-create in object_store; the
+/// bucket must exist before put.
+fn create_bucket(host: &str, port: u16, bucket: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let url = format!("http://{host}:{port}/{bucket}");
+        let client = reqwest::Client::new();
+        let resp = client
+            .put(&url)
+            .basic_auth(MINIO_USER, Some(MINIO_PASSWORD))
+            .send()
+            .await?;
+        // 200 (created) or 409 (already exists) both fine.
+        let status = resp.status();
+        if !status.is_success() && status.as_u16() != 409 {
+            let body = resp.text().await.unwrap_or_default();
+            return Err::<(), Box<dyn std::error::Error>>(
+                format!("create bucket failed: {status} {body}").into(),
+            );
+        }
+        Ok(())
+    })
+}
+
+fn write_bundle(root: &Path) {
+    std::fs::create_dir_all(root).unwrap();
+    std::fs::write(root.join("manifest.json"), b"{\"v\":1}").unwrap();
+    std::fs::create_dir_all(root.join("steps")).unwrap();
+    std::fs::write(root.join("steps").join("a.json"), b"step-a").unwrap();
+    std::fs::write(root.join("steps").join("b.json"), b"step-b").unwrap();
+    std::fs::create_dir_all(root.join("attachments").join("nested")).unwrap();
+    std::fs::write(
+        root.join("attachments").join("nested").join("c.bin"),
+        b"binary-content",
+    )
+    .unwrap();
+}
+
+/// Serialize the tests in this file. testcontainers + the AWS_* env
+/// vars + the shared `INIT` lock keep them from racing.
+static SERIAL: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+fn serial_lock() -> std::sync::MutexGuard<'static, ()> {
+    SERIAL
+        .get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+#[test]
+fn s3_put_then_get_roundtrips() {
+    let _g = serial_lock();
+    let Some(container) = try_start_minio() else {
+        return;
+    };
+    let host = container.get_host().expect("get_host").to_string();
+    let port = container
+        .get_host_port_ipv4(MINIO_PORT.tcp())
+        .expect("get_host_port");
+
+    set_aws_env(&host, port);
+    create_bucket(&host, port, "boruna-test").expect("create bucket");
+
+    let cache = tempfile::tempdir().unwrap();
+    let bundle_dir = tempfile::tempdir().unwrap();
+    write_bundle(bundle_dir.path());
+
+    let store = S3BucketBuilder::new("s3://boruna-test/audit/prod")
+        .with_cache_root(cache.path().to_path_buf())
+        .build()
+        .expect("build S3Bucket");
+
+    let r = store.put("run-roundtrip", bundle_dir.path()).expect("put");
+    assert_eq!(r.0, "s3://boruna-test/audit/prod/run-roundtrip");
+
+    let resolved = store.get(&r).expect("get");
+    assert!(resolved.exists());
+    assert!(resolved.join("manifest.json").exists());
+    assert_eq!(
+        std::fs::read(resolved.join("manifest.json")).unwrap(),
+        b"{\"v\":1}"
+    );
+    assert_eq!(
+        std::fs::read(resolved.join("steps").join("a.json")).unwrap(),
+        b"step-a"
+    );
+    assert_eq!(
+        std::fs::read(resolved.join("attachments").join("nested").join("c.bin")).unwrap(),
+        b"binary-content"
+    );
+}
+
+#[test]
+fn s3_get_returns_not_found_for_missing_run() {
+    let _g = serial_lock();
+    let Some(container) = try_start_minio() else {
+        return;
+    };
+    let host = container.get_host().expect("get_host").to_string();
+    let port = container
+        .get_host_port_ipv4(MINIO_PORT.tcp())
+        .expect("get_host_port");
+
+    set_aws_env(&host, port);
+    create_bucket(&host, port, "boruna-test-missing").expect("create bucket");
+
+    let cache = tempfile::tempdir().unwrap();
+    let store = S3BucketBuilder::new("s3://boruna-test-missing")
+        .with_cache_root(cache.path().to_path_buf())
+        .build()
+        .expect("build");
+
+    let err = store
+        .get(&StorageRef(
+            "s3://boruna-test-missing/never-uploaded".into(),
+        ))
+        .unwrap_err();
+    use boruna_orchestrator::audit::storage::StorageError;
+    assert!(matches!(err, StorageError::NotFound(_)), "got {err:?}");
+}
+
+#[test]
+fn s3_list_returns_uploaded_run_ids_in_sorted_order() {
+    let _g = serial_lock();
+    let Some(container) = try_start_minio() else {
+        return;
+    };
+    let host = container.get_host().expect("get_host").to_string();
+    let port = container
+        .get_host_port_ipv4(MINIO_PORT.tcp())
+        .expect("get_host_port");
+
+    set_aws_env(&host, port);
+    create_bucket(&host, port, "boruna-test-list").expect("create bucket");
+
+    let cache = tempfile::tempdir().unwrap();
+    let store = S3BucketBuilder::new("s3://boruna-test-list/audit")
+        .with_cache_root(cache.path().to_path_buf())
+        .build()
+        .expect("build");
+
+    let bundle = tempfile::tempdir().unwrap();
+    write_bundle(bundle.path());
+
+    for run_id in ["run-c", "run-a", "run-b"] {
+        store.put(run_id, bundle.path()).expect("put");
+    }
+
+    let refs: Vec<String> = store
+        .list(None)
+        .expect("list")
+        .into_iter()
+        .map(|r| r.0)
+        .collect();
+    assert_eq!(
+        refs,
+        vec![
+            "s3://boruna-test-list/audit/run-a".to_string(),
+            "s3://boruna-test-list/audit/run-b".to_string(),
+            "s3://boruna-test-list/audit/run-c".to_string(),
+        ]
+    );
+
+    let filtered: Vec<String> = store
+        .list(Some("run-a"))
+        .expect("list filtered")
+        .into_iter()
+        .map(|r| r.0)
+        .collect();
+    assert_eq!(
+        filtered,
+        vec!["s3://boruna-test-list/audit/run-a".to_string()]
+    );
+}


### PR DESCRIPTION
## Summary

Implements the first remote-storage adapter for the `BundleStorage` trait shipped in T-2.3 (#25). Uses Apache Arrow `object_store` with the `aws` feature so T-3.2 (GCS) and T-3.3 (Azure Blob) can land as small follow-ups by toggling additional features on the same crate.

`s3://bucket[/prefix]` URIs now construct a real adapter when the binary is built with `--features boruna-cli/s3` (or `boruna-orchestrator/s3` for downstream library consumers). When the feature is OFF, the URI rejects at parse time with an actionable message that points operators at the feature flag — never silently ignored, which would have produced an audit gap.

## Design choices

- **`object_store` over `aws-sdk-s3`.** Lighter dep tree, unified abstraction across S3/GCS/Azure, used by Polars/DataFusion in production. T-3.2 and T-3.3 become single-feature-toggle PRs on top of this work.
- **Sync trait, async SDK.** Bridged via a per-instance current-thread tokio runtime owned by `S3Bucket`. Trait stays sync because every call site (CLI, orchestrator background thread) is sync.
- **Local cache root.** `get` materializes into `BORUNA_BUNDLE_CACHE` (default `<temp>/boruna-bundle-cache`). Idempotent: each `get` clears and re-materializes the run's cache directory, since bundle finalize is deterministic so the bytes are identical anyway.
- **Stable `error_kind` taxonomy.** `s3.transient` (network/throttle), `s3.permanent` (auth/NoSuchBucket), `s3.runtime` (couldn't build tokio runtime), `s3.unexpected_key` (object outside expected prefix). Per project conventions §2.

## Files

- `orchestrator/src/audit/storage_s3.rs` — adapter + builder + URI parser. 16 unit tests cover URI parsing, object-path concat, ref-to-run-id extraction, error-kind classification, and cache-root resolution.
- `orchestrator/tests/s3_integration.rs` — testcontainers + MinIO round-trip behind `s3-it` feature. Self-skips when Docker is unreachable.
- `orchestrator/src/audit/storage.rs` — `from_uri` dispatches to `S3Bucket::from_uri` when `s3` feature is on; otherwise rejects with actionable message.
- `crates/llmvm-cli/Cargo.toml` — forwards `s3` feature to orchestrator.
- `crates/llmvm-cli/src/main.rs` — updated `--bundle-storage` help text.
- `docs/guides/bundle-storage-s3.md` — operator guide (auth, IAM policy, MinIO local-test recipe, error taxonomy, limitations).
- `CHANGELOG.md` — `### Added` entry.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo test -p boruna-orchestrator --features s3` — 415 tests + 16 new s3 unit tests
- [x] `cargo test -p boruna-orchestrator --features s3-it --test s3_integration` — self-skips cleanly without Docker
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p boruna-orchestrator --features s3-it --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Operator follow-up: run `cargo test -p boruna-orchestrator --features s3-it --test s3_integration -- --nocapture` on a host with Docker to exercise the full MinIO round-trip.

## Follow-ups (not in this PR)

- T-3.2 GCS adapter — toggles `object_store/gcp` feature; same shape.
- T-3.3 Azure Blob adapter — toggles `object_store/azure` feature.
- `evidence verify` against an `s3://` ref directly (currently requires a separate `get` call to materialize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)