### PR TITLE
feat(post1-T-1.2): BYOH reference handler library (Anthropic / Ollama / vLLM / Bedrock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **BYOH reference handler library** (post1-T-1.2). Four new
+  reference `CapabilityHandler` implementations under
+  `examples/llm_handlers/` joining the existing OpenAI example:
+  Anthropic (Messages API), Ollama (local-LLM, deterministic-with-seed),
+  vLLM-and-OpenAI-compatible (one handler covers vLLM/OpenRouter/
+  Together/Groq/LiteLLM), and AWS Bedrock (skeleton using the AWS
+  SDK because hand-rolling SigV4 adds nothing illustrative). Each
+  is a self-contained ~80–120-LOC copy-and-tweak template with a
+  README documenting auth, response shape, determinism options,
+  and what the reference deliberately omits (multi-provider
+  routing, streaming, cost accounting, etc.). New umbrella
+  `examples/llm_handlers/README.md` indexes the library and
+  cross-references the built-in `LlmRouterHandler` (sprint
+  0.4-S13). New `providers.toml.example` documents a config-schema
+  *convention* integrators can adopt for declarative router setup
+  (Boruna does not parse this file); new `router_setup.rs`
+  shows a reference parser that turns the toml into an
+  `LlmRouterHandler`.
+
+  This expansion is faithful to the BYOH design contract shipped
+  in 0.3-S8: Boruna does not ship default handlers in core. Each
+  reference is integrator-copyable code, not a Cargo dep.
+  Auditing the original T-1.2 plan ("ship a `boruna-effect-providers`
+  adapter crate") against the shipped BYOH guide flagged the
+  premise conflict before any code was written; the reframed
+  scope delivers the spirit of "more provider on-ramps" without
+  violating the contract.
+
 ### Changed
 
 - **`BundleStorage` trait promoted to public 1.x API surface.**

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -103,18 +103,25 @@ impl OpenAiHandler {
 }
 ```
 
-A complete runnable example lives in `examples/llm_handlers/openai/`. The example is built with `cargo build --example openai-handler --features http` and shows how to wire the handler into a `WorkflowRunner` invocation.
+A complete reference handler lives in `examples/llm_handlers/openai/`. The directory contains `handler.rs` (a self-contained module you can copy into your integrator crate) and a README documenting the per-provider gotchas.
 
 ## Provider variants
 
-The same pattern works for any HTTP-API LLM provider:
+Reference handlers ship for the most common providers (post1-T-1.2). Each is a copy-and-tweak template, **not** a compiled crate Boruna pulls in:
 
-- **Anthropic**: change the URL to `https://api.anthropic.com/v1/messages`, the header to `x-api-key`, and the response path to `content[0].text`.
-- **vLLM / OpenAI-compatible self-hosted**: change just the URL.
-- **Ollama (local)**: URL `http://localhost:11434/api/generate`, no auth, response path `response`.
-- **Custom router**: whatever your routing layer expects.
+| Provider | Use when | Path |
+|---|---|---|
+| OpenAI | api.openai.com | [`examples/llm_handlers/openai/`](../../examples/llm_handlers/openai/) |
+| Anthropic | api.anthropic.com | [`examples/llm_handlers/anthropic/`](../../examples/llm_handlers/anthropic/) |
+| Ollama | local development, air-gapped CI | [`examples/llm_handlers/ollama/`](../../examples/llm_handlers/ollama/) |
+| vLLM (and OpenAI-compatible proxies) | self-hosted vLLM, OpenRouter, Together, Groq, LiteLLM | [`examples/llm_handlers/vllm/`](../../examples/llm_handlers/vllm/) |
+| AWS Bedrock | Bedrock-hosted Claude / Llama / Titan / Mistral / Cohere | [`examples/llm_handlers/bedrock/`](../../examples/llm_handlers/bedrock/) |
 
-For multi-provider routing, your handler can switch on a `model` argument (passed as `args[1]`) or on a thread-local context.
+The umbrella [`examples/llm_handlers/README.md`](../../examples/llm_handlers/README.md) gives the cross-provider overview and links each handler's gotchas (auth header, response path, determinism options).
+
+A documented `providers.toml.example` schema and a [`router_setup.rs`](../../examples/llm_handlers/router_setup.rs) reference parser show one convention for declaring your provider lineup in config rather than code. The format is a starting point — Boruna does not parse it.
+
+For multi-provider routing, use the built-in `LlmRouterHandler` (covered next), or have your handler switch on a `model` argument (passed as `args[1]`) or on a thread-local context.
 
 ### `LlmRouterHandler` — built-in multi-provider dispatch (sprint `0.4-S13`)
 

--- a/examples/llm_handlers/README.md
+++ b/examples/llm_handlers/README.md
@@ -1,0 +1,73 @@
+# LLM Handler Examples — BYOH Reference Library
+
+This directory contains reference `CapabilityHandler` implementations for the most common LLM providers. They demonstrate the **Bring Your Own Handler (BYOH)** integration pattern Boruna uses for `Capability::LlmCall` — see [`docs/guides/llm-integration.md`](../../docs/guides/llm-integration.md) for the design rationale.
+
+**These are reference snippets, not compiled examples.** Each handler is ~80–120 LOC of self-contained code; copy the `handler.rs` into your integrator crate and adapt for your provider, secret management, observability, and routing concerns.
+
+## Why BYOH (and not a shipped adapter crate)?
+
+Provider APIs churn. API keys need org-specific secret management. Production integrators usually already have an LLM client. Shipping default handlers in core would constrain integrators and tie Boruna's release cadence to provider releases. See the [LLM integration guide](../../docs/guides/llm-integration.md#why-byoh) for the full discussion.
+
+## Available handlers
+
+| Provider | Use when | Path |
+|---|---|---|
+| **OpenAI** | Talking directly to api.openai.com | [`openai/`](./openai/) |
+| **Anthropic** | Talking directly to api.anthropic.com | [`anthropic/`](./anthropic/) |
+| **Ollama** | Local development, air-gapped CI, deterministic-with-seed runs | [`ollama/`](./ollama/) |
+| **vLLM (and OpenAI-compatible proxies)** | Self-hosted vLLM, OpenRouter, Together, Groq, LiteLLM, SGLang | [`vllm/`](./vllm/) |
+| **AWS Bedrock** | Bedrock-hosted Claude / Llama / Titan / Mistral / Cohere via SigV4 | [`bedrock/`](./bedrock/) |
+
+Each subdirectory has a `handler.rs` and a `README.md`. The READMEs document the per-provider gotchas (auth, response shape, determinism options, what the reference deliberately omits).
+
+## Multi-provider routing
+
+Boruna ships a **pure-routing** primitive in `boruna-vm`: `LlmRouterHandler` (`crates/llmvm/src/capability_gateway.rs`). It dispatches `Capability::LlmCall` to a registered provider handler based on a `provider/model` prefix in `args[1]`. The router itself adds zero provider compatibility commitments to core.
+
+Compose any subset of the handler examples above into a router:
+
+```rust
+use std::collections::BTreeMap;
+use boruna_vm::capability_gateway::{
+    CapabilityHandler, LlmRouterHandler, MockHandler,
+};
+
+let mut providers: BTreeMap<String, Box<dyn CapabilityHandler>> = BTreeMap::new();
+providers.insert("openai".into(),    Box::new(OpenAiHandler::from_env()?));
+providers.insert("anthropic".into(), Box::new(AnthropicHandler::from_env()?));
+providers.insert("ollama".into(),    Box::new(OllamaHandler::from_env()?));
+
+let router = LlmRouterHandler::new(providers, Box::new(MockHandler));
+
+// In .ax: let r1 = llm_call("Summarize:", "openai/gpt-4o-mini")
+//         let r2 = llm_call("Critique:",  "anthropic/claude-sonnet-4-6")
+// Router parses the prefix and dispatches to the right handler.
+```
+
+See [`router_setup.rs`](./router_setup.rs) for a more complete example, including loading a routing table from `providers.toml.example`.
+
+## Declarative routing config (optional)
+
+For integrators who want to declare their provider lineup in config rather than code, [`providers.toml.example`](./providers.toml.example) shows a documented schema. The format is a starting point — adopt, extend, or ignore as fits your deployment. Boruna does not parse this file; the schema is just a convention for integrators who want a uniform shape.
+
+[`router_setup.rs`](./router_setup.rs) shows a reference parser that turns the toml into an `LlmRouterHandler`.
+
+## Pattern across all examples
+
+Every reference handler follows the same shape so integrators can copy-and-tweak:
+
+1. **Construct from env** — `from_env() -> Result<Self, String>`. Read API keys, base URLs, model defaults.
+2. **Builder methods** — `with_model`, `with_endpoint`, `with_api_key` (where applicable). Override env defaults programmatically.
+3. **`handle_llm_call`** — extract the prompt from `args[0]` (a `Value::String`), POST to the provider, parse the response. Return `Value::String`.
+4. **`CapabilityHandler::handle`** — match `Capability::LlmCall` and route to `handle_llm_call`; everything else falls through to `MockHandler`.
+5. **`temperature: 0` by default** — for replay-friendliness. Override in your fork if you need sampling diversity.
+
+## Determinism guidance
+
+Across all providers:
+- **Pin model versions** to dated snapshots (`gpt-4o-mini-2024-07-18`, not `gpt-4o-mini`).
+- **`temperature: 0`** in the request body.
+- **Set `seed`** where the provider supports it (Ollama: yes; vLLM: yes; Anthropic: no; OpenAI: yes via `seed` parameter; Bedrock-hosted models: varies).
+- **Record + replay**: `boruna workflow run --record-net-to <tape>` captures HTTP traffic; `--replay-net-from <tape>` replays it. This works for HTTP-based handlers (everyone except Bedrock, which goes through the AWS SDK rather than Boruna's HTTP recorder).
+
+See [`docs/guides/llm-integration.md`](../../docs/guides/llm-integration.md) for the full discussion of why BYOH, what the trait contract looks like, and how to wire a handler into a `WorkflowRunner` invocation.

--- a/examples/llm_handlers/anthropic/README.md
+++ b/examples/llm_handlers/anthropic/README.md
@@ -1,0 +1,46 @@
+# Anthropic LLM Handler — Reference Example
+
+This directory contains a reference implementation of a `CapabilityHandler` that routes `llm.call` capability invocations to the Anthropic Messages API.
+
+**This is a reference only — not a production handler.** It demonstrates the BYOH (Bring Your Own Handler) integration pattern documented in [`docs/guides/llm-integration.md`](../../../docs/guides/llm-integration.md). Production deployments should fork this and harden it for their own provider, secret management, observability, and routing concerns.
+
+## Files
+
+- `handler.rs` — the `AnthropicHandler` struct and its `CapabilityHandler` impl. Self-contained: no Boruna-internal dependencies beyond `boruna-vm` and `boruna-bytecode`.
+
+## How it differs from the OpenAI handler
+
+The shape is intentionally near-identical so integrators can copy-and-tweak. The Anthropic-specific points:
+
+| Concern | OpenAI | Anthropic |
+|---|---|---|
+| Endpoint | `/v1/chat/completions` | `/v1/messages` |
+| Auth header | `Authorization: Bearer <key>` | `x-api-key: <key>` |
+| Version pin | (URL only) | `anthropic-version: 2023-06-01` (required header) |
+| `max_tokens` | optional | **required** — no "unlimited" |
+| Response path | `choices[0].message.content` | `content[0].text` |
+| Multi-turn shape | `{role, content}` flat strings | `{role, content}` with content as list-of-blocks |
+
+## Building
+
+The handler depends on `ureq` (HTTP client). Copy the file into your integrator crate, add `ureq = "2"` and `serde_json = "1"`, then wire the handler into your runner via `boruna_orchestrator::WorkflowRunner::with_handler` (or the equivalent in your harness).
+
+## What it doesn't do
+
+Deliberately omitted (these belong in your fork, not in a reference):
+
+- **Multi-provider routing.** Single hard-coded endpoint. See `examples/llm_handlers/router_setup.rs` and `boruna_vm::capability_gateway::LlmRouterHandler` for the multi-provider dispatch pattern.
+- **Token counting / budget tracking.** `boruna_orchestrator`'s per-step `budget.max_calls` covers call-count budgeting.
+- **Retry on rate-limit / `429`.** Boruna's `RetryPolicy` (sprint `0.3-S5`) applies at the step level. For finer-grained retry-within-handler, add your own backoff loop reading the `retry-after` header Anthropic sends on overload.
+- **Streaming.** Boruna's capability calls are synchronous; streaming responses must be collected.
+- **Tool use.** This handler only extracts the first `content[i].text`. If you use Anthropic's tool-use protocol, branch on `content[i].type` (`text` vs `tool_use`).
+- **Cost accounting.** Track usage by intercepting in your handler's `handle` method (Anthropic returns `usage.input_tokens` + `usage.output_tokens`).
+
+## Determinism
+
+This handler is non-deterministic at the LLM layer. For reproducible runs:
+- Set `temperature: 0` in the request body (the default in this example).
+- Pin the model version to a dated snapshot, e.g. `claude-sonnet-4-6` is the family alias — for replay reproducibility prefer the dated variant when Anthropic publishes one.
+- Use `boruna workflow run --record-net-to <tape>` to capture the session, then `--replay-net-from <tape>` for replay (sprint `0.5-S7`).
+
+See [`docs/guides/llm-integration.md`](../../../docs/guides/llm-integration.md) for the full discussion.

--- a/examples/llm_handlers/anthropic/handler.rs
+++ b/examples/llm_handlers/anthropic/handler.rs
@@ -1,0 +1,108 @@
+//! Reference `CapabilityHandler` impl for Anthropic Messages API.
+//!
+//! This is a reference for the BYOH integration pattern documented in
+//! `docs/guides/llm-integration.md` — NOT a production handler. Fork and
+//! harden for your own provider, secret management, observability, and
+//! routing concerns.
+
+use boruna_bytecode::{Capability, Value};
+use boruna_vm::capability_gateway::{CapabilityHandler, MockHandler};
+
+/// LLM handler that routes `llm.call` to Anthropic's Messages API.
+///
+/// All other capabilities (`fs.read`, `time.now`, etc.) fall through to
+/// `MockHandler`. Production handlers should compose with their full
+/// capability surface, not just llm.call.
+pub struct AnthropicHandler {
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+    client: ureq::Agent,
+}
+
+impl AnthropicHandler {
+    /// Construct from `ANTHROPIC_API_KEY` env var. Defaults to the
+    /// latest Sonnet snapshot — pin to a dated model for replay
+    /// reproducibility.
+    pub fn from_env() -> Result<Self, String> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .map_err(|_| "ANTHROPIC_API_KEY not set".to_string())?;
+        Ok(Self {
+            api_key,
+            model: "claude-sonnet-4-6".to_string(),
+            max_tokens: 4096,
+            client: ureq::AgentBuilder::new()
+                .timeout(std::time::Duration::from_secs(60))
+                .build(),
+        })
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    fn handle_llm_call(&self, args: &[Value]) -> Result<Value, String> {
+        let prompt = args
+            .first()
+            .and_then(|v| match v {
+                Value::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .ok_or_else(|| "llm.call: first arg must be a String prompt".to_string())?;
+
+        // Anthropic's Messages API requires `max_tokens`. There is no
+        // "unlimited" option; pick an upper bound that fits your
+        // workload's longest expected response.
+        let body = serde_json::json!({
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": [{"role": "user", "content": prompt}],
+            // Pin temperature for replay-friendliness. Override in
+            // your fork if you need sampling diversity.
+            "temperature": 0,
+        });
+
+        let resp = self
+            .client
+            .post("https://api.anthropic.com/v1/messages")
+            // Anthropic uses `x-api-key`, NOT `Authorization: Bearer`.
+            .set("x-api-key", &self.api_key)
+            // The version header is required and pins the wire shape.
+            // Keep this in sync with your prompt assumptions.
+            .set("anthropic-version", "2023-06-01")
+            .set("Content-Type", "application/json")
+            .send_json(body)
+            .map_err(|e| format!("anthropic request failed: {e}"))?;
+
+        let json: serde_json::Value = resp
+            .into_json()
+            .map_err(|e| format!("anthropic response parse: {e}"))?;
+        // Anthropic returns `content: [{type: "text", text: "..."}]`
+        // (a list of content blocks). Most calls return a single text
+        // block; we extract `content[0].text`. If your prompt reliably
+        // produces tool-use blocks, branch on `content[i].type`.
+        let content = json
+            .get("content")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("text"))
+            .and_then(|c| c.as_str())
+            .ok_or_else(|| "anthropic response missing content[0].text".to_string())?;
+
+        Ok(Value::String(content.to_string()))
+    }
+}
+
+impl CapabilityHandler for AnthropicHandler {
+    fn handle(&mut self, cap: &Capability, args: &[Value]) -> Result<Value, String> {
+        match cap {
+            Capability::LlmCall => self.handle_llm_call(args),
+            _ => MockHandler.handle(cap, args),
+        }
+    }
+}

--- a/examples/llm_handlers/bedrock/README.md
+++ b/examples/llm_handlers/bedrock/README.md
@@ -1,0 +1,97 @@
+# AWS Bedrock LLM Handler — Reference Skeleton
+
+Reference skeleton for routing `llm.call` to AWS Bedrock's `InvokeModel` API. Bedrock signs every request with AWS SigV4; rather than hand-roll signing (~100 LOC of HMAC plumbing), this skeleton uses the official `aws-sdk-bedrockruntime` crate.
+
+**This is a reference skeleton — not a production handler.** It compiles in your fork once you wire in a real `aws_sdk_bedrockruntime::Client` (the file uses a `BedrockClient` placeholder so the example doesn't drag the AWS SDK into Boruna's workspace).
+
+## Setup
+
+In your integrator crate:
+
+```toml
+[dependencies]
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-bedrockruntime = "1"
+tokio = { version = "1", features = ["rt"] }
+serde_json = "1"
+boruna-vm = { path = "..." }
+boruna-bytecode = { path = "..." }
+```
+
+Replace the placeholder `BedrockClient` and the `from_env` body with:
+
+```rust
+let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+    .load()
+    .await;
+let client = aws_sdk_bedrockruntime::Client::new(&config);
+```
+
+## IAM requirements
+
+Attach a role with at minimum:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["bedrock:InvokeModel"],
+    "Resource": "arn:aws:bedrock:<region>::foundation-model/<model-id>"
+  }]
+}
+```
+
+Bedrock model access also needs to be **explicitly granted** in the AWS console (AWS Bedrock → Model access → request access for each foundation model your account uses).
+
+## Configuration
+
+| Variable | Purpose |
+|---|---|
+| `BEDROCK_MODEL_ID` | e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`, `anthropic.claude-sonnet-4-5-20241022-v2:0`, `meta.llama3-1-70b-instruct-v1:0` |
+| `AWS_REGION` | Read by the AWS SDK; pick a region where your model is available |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` | Standard AWS credential chain — IAM role / IMDS / SSO / env all work |
+
+## Sync trait, async SDK
+
+`CapabilityHandler::handle` is sync; the AWS SDK is async. The skeleton owns a per-instance `tokio::runtime::Runtime` and `block_on`s each call. This is the same pattern Boruna's S3 / GCS / Azure `BundleStorage` adapters use — see `orchestrator/src/audit/storage_s3.rs` for the canonical discussion.
+
+## Model-family wire shape
+
+Bedrock's `InvokeModel` returns the model's raw response body verbatim — the wire shape is **per model family**. This skeleton shows the **Anthropic-on-Bedrock** request body (Claude family). For others:
+
+| Family | Request shape | Response shape |
+|---|---|---|
+| Anthropic (Claude) | `{anthropic_version, max_tokens, messages, temperature}` | `content[0].text` |
+| Meta (Llama) | `{prompt, max_gen_len, temperature}` | `generation` |
+| Amazon (Titan) | `{inputText, textGenerationConfig: {maxTokenCount, temperature}}` | `results[0].outputText` |
+| Mistral | `{prompt, max_tokens, temperature}` | `outputs[0].text` |
+| Cohere (Command) | `{message, max_tokens, temperature}` | `text` |
+
+Replace the `serde_json::json!` body and the response-extraction `.get("content")` chain to match your model.
+
+## Cross-region inference profiles
+
+For production workloads, use Bedrock's **cross-region inference profiles** (e.g. `us.anthropic.claude-...`) rather than direct model IDs. They give you automatic failover across regions with no code changes.
+
+```bash
+export BEDROCK_MODEL_ID="us.anthropic.claude-sonnet-4-5-20241022-v2:0"
+```
+
+## What this skeleton doesn't do
+
+- **Provisioned throughput.** For high-volume workloads, request a Provisioned Throughput unit (PT) and pass its ARN as `model_id` instead of the foundation-model ID.
+- **Guardrails.** Bedrock has a separate `apply_guardrail` API and an `applyGuardrails` parameter on `InvokeModel`. Wire those in if your compliance posture requires content filtering.
+- **Streaming.** Use `invoke_model_with_response_stream` for streaming, but Boruna's capability calls are synchronous so you'll need to collect the stream before returning.
+- **Cost accounting.** Bedrock returns `usage.input_tokens` + `usage.output_tokens` in the response — extract them in your handler if you need per-call cost tracking.
+
+## Determinism
+
+Bedrock-served models inherit their underlying determinism story:
+- **Anthropic-on-Bedrock**: `temperature: 0` is honored; no `seed` parameter.
+- **Llama-on-Bedrock**: `temperature: 0` only.
+- **Titan / Mistral / Cohere**: same — `temperature: 0`, no seed.
+
+For full reproducibility, combine with `boruna workflow run --record-net-to <tape>`. But note: AWS SDK calls don't go through Boruna's `RecordingHttpHandler` — you'd need to record at the SDK layer (e.g. `aws_smithy_runtime` interceptors) or use Boruna's `--replay-net-from` only for non-Bedrock capabilities in the same workflow.
+
+See [`docs/guides/llm-integration.md`](../../../docs/guides/llm-integration.md) for the full discussion.

--- a/examples/llm_handlers/bedrock/handler.rs
+++ b/examples/llm_handlers/bedrock/handler.rs
@@ -1,0 +1,140 @@
+//! Reference `CapabilityHandler` skeleton for AWS Bedrock.
+//!
+//! Bedrock signs every request with AWS SigV4. Hand-rolling SigV4
+//! is ~100 LOC of HMAC-SHA256 plumbing that adds nothing
+//! illustrative, so this skeleton uses the official AWS SDK
+//! (`aws-sdk-bedrockruntime`) instead. Adopt the pattern shown
+//! here and adapt to your IAM / region / model choice.
+//!
+//! This is a reference for the BYOH integration pattern documented in
+//! `docs/guides/llm-integration.md` — NOT a production handler.
+//!
+//! ## Required dependencies for your fork
+//!
+//! ```toml
+//! [dependencies]
+//! aws-config = { version = "1", features = ["behavior-version-latest"] }
+//! aws-sdk-bedrockruntime = "1"
+//! tokio = { version = "1", features = ["rt"] }
+//! serde_json = "1"
+//! ```
+//!
+//! ## Why a per-instance tokio runtime?
+//!
+//! `CapabilityHandler::handle` is sync; the AWS SDK is async. We
+//! own a `tokio::runtime::Runtime` per `BedrockHandler` instance and
+//! `block_on` each call. Same pattern Boruna's S3 / GCS / Azure
+//! `BundleStorage` adapters use — see
+//! `orchestrator/src/audit/storage_s3.rs` for the canonical
+//! discussion.
+
+use boruna_bytecode::{Capability, Value};
+use boruna_vm::capability_gateway::{CapabilityHandler, MockHandler};
+
+// NOTE: this snippet uses placeholder type names so the reference
+// compiles in the user's mind without dragging the AWS SDK into
+// Boruna's workspace. In your fork, replace these with the real
+// `aws_sdk_bedrockruntime::Client` etc.
+//
+// Mark these `unimplemented!()` so a copy-paste user gets a clear
+// "you need to wire this" message at runtime if they forget to
+// substitute a real client.
+struct BedrockClient;
+impl BedrockClient {
+    async fn invoke_model(&self, _model_id: &str, _body: Vec<u8>) -> Result<Vec<u8>, String> {
+        unimplemented!(
+            "replace BedrockClient with aws_sdk_bedrockruntime::Client \
+             and call .invoke_model().model_id(...).body(...).send().await"
+        )
+    }
+}
+
+/// LLM handler that routes `llm.call` to AWS Bedrock's
+/// `InvokeModel` API.
+///
+/// The wire shape varies by underlying model family. This skeleton
+/// shows the **Anthropic-on-Bedrock** request shape (Claude models),
+/// which is the most commonly-deployed combination. For Llama on
+/// Bedrock, swap the request body for Llama's prompt format; for
+/// Titan, swap to Titan's `inputText`+`textGenerationConfig`
+/// shape. Bedrock's `InvokeModel` returns the model's raw
+/// response body — your handler is responsible for parsing it.
+pub struct BedrockHandler {
+    client: BedrockClient,
+    model_id: String,
+    runtime: std::sync::Arc<tokio::runtime::Runtime>,
+}
+
+impl BedrockHandler {
+    /// Construct from the standard AWS env / shared-config / IMDS
+    /// credential chain. `BEDROCK_MODEL_ID` selects the model
+    /// (e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`).
+    ///
+    /// In your fork:
+    /// ```ignore
+    /// let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+    ///     .load()
+    ///     .await;
+    /// let client = aws_sdk_bedrockruntime::Client::new(&config);
+    /// ```
+    pub fn from_env() -> Result<Self, String> {
+        let model_id = std::env::var("BEDROCK_MODEL_ID")
+            .map_err(|_| "BEDROCK_MODEL_ID not set".to_string())?;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("bedrock: failed to build tokio runtime: {e}"))?;
+        Ok(Self {
+            client: BedrockClient, // replace with real aws_sdk_bedrockruntime::Client
+            model_id,
+            runtime: std::sync::Arc::new(runtime),
+        })
+    }
+
+    fn handle_llm_call(&self, args: &[Value]) -> Result<Value, String> {
+        let prompt = args
+            .first()
+            .and_then(|v| match v {
+                Value::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .ok_or_else(|| "llm.call: first arg must be a String prompt".to_string())?;
+
+        // Anthropic-on-Bedrock request shape. For other model
+        // families, swap this body construction.
+        let body = serde_json::json!({
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 4096,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+        });
+        let body_bytes = serde_json::to_vec(&body)
+            .map_err(|e| format!("bedrock body serialize: {e}"))?;
+
+        let resp_bytes = self.runtime.block_on(async {
+            self.client.invoke_model(&self.model_id, body_bytes).await
+        })?;
+
+        let json: serde_json::Value = serde_json::from_slice(&resp_bytes)
+            .map_err(|e| format!("bedrock response parse: {e}"))?;
+        // Anthropic-on-Bedrock response: `{content: [{type, text}], ...}`
+        // — same shape as the direct Anthropic API.
+        let content = json
+            .get("content")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("text"))
+            .and_then(|c| c.as_str())
+            .ok_or_else(|| "bedrock response missing content[0].text".to_string())?;
+
+        Ok(Value::String(content.to_string()))
+    }
+}
+
+impl CapabilityHandler for BedrockHandler {
+    fn handle(&mut self, cap: &Capability, args: &[Value]) -> Result<Value, String> {
+        match cap {
+            Capability::LlmCall => self.handle_llm_call(args),
+            _ => MockHandler.handle(cap, args),
+        }
+    }
+}

--- a/examples/llm_handlers/ollama/README.md
+++ b/examples/llm_handlers/ollama/README.md
@@ -1,0 +1,54 @@
+# Ollama LLM Handler — Reference Example
+
+Reference implementation of a `CapabilityHandler` that routes `llm.call` to a local [Ollama](https://ollama.com/) daemon. Handy for offline development, air-gapped deployments, and CI/test runs against small local models.
+
+**This is a reference only — not a production handler.** See [`docs/guides/llm-integration.md`](../../../docs/guides/llm-integration.md) for the BYOH integration model.
+
+## Why use Ollama with Boruna?
+
+- **Reproducible local dev.** No external API key needed; spin up `ollama serve` and iterate against a 3B-parameter model.
+- **Deterministic-ish.** Ollama supports a `seed` parameter; combined with `temperature: 0` you get bit-for-bit reproducibility within a single model version.
+- **Air-gapped CI.** Burn the model into the CI image once, then no network egress is required for LLM-using workflows.
+
+## Setup
+
+```bash
+# Install Ollama (macOS)
+brew install ollama
+ollama serve &
+
+# Pull the model the handler defaults to
+ollama pull llama3.2:3b
+```
+
+Then point Boruna at the daemon (default `http://localhost:11434` matches Ollama's own default — no env config needed for local use).
+
+## Files
+
+- `handler.rs` — the `OllamaHandler` struct and its `CapabilityHandler` impl.
+
+## Configuration
+
+| Variable | Default | Notes |
+|---|---|---|
+| `OLLAMA_HOST` | `http://localhost:11434` | Override to point at a remote/network-mounted daemon |
+| (model) | `llama3.2:3b` | Override via `with_model("...")` — must already be pulled |
+
+## What it doesn't do
+
+- **Multi-provider routing.** Single endpoint. See `examples/llm_handlers/router_setup.rs` for the multi-provider dispatch pattern.
+- **Streaming.** Boruna's capability calls are synchronous; this handler sets `stream: false` and collects the single JSON response.
+- **Multi-turn chat.** Uses `/api/generate` (single prompt). Switch to `/api/chat` and pass `messages: [...]` for conversation context.
+- **Model auto-pull.** If the model isn't already loaded, Ollama returns a 404 — surface this in your fork as a clearer error.
+- **GPU detection / load balancing.** Ollama handles those internally per-instance.
+
+## Determinism
+
+Ollama is the easiest LLM to make deterministic:
+- `temperature: 0` (set by default in this example).
+- `seed: 42` (set by default — change but pin for your replay tape).
+- Pin the model tag to a content-addressed digest if you really care: `ollama pull llama3.2:3b@sha256:...` and reference the digest in `with_model`.
+
+Combined with `boruna workflow run --record-net-to <tape>`, you get a fully replayable session.
+
+See [`docs/guides/llm-integration.md`](../../../docs/guides/llm-integration.md) for the full discussion.

--- a/examples/llm_handlers/ollama/handler.rs
+++ b/examples/llm_handlers/ollama/handler.rs
@@ -1,0 +1,106 @@
+//! Reference `CapabilityHandler` impl for Ollama (local-LLM runner).
+//!
+//! This is a reference for the BYOH integration pattern documented in
+//! `docs/guides/llm-integration.md` — NOT a production handler. Fork
+//! and harden as needed.
+
+use boruna_bytecode::{Capability, Value};
+use boruna_vm::capability_gateway::{CapabilityHandler, MockHandler};
+
+/// LLM handler that routes `llm.call` to a local Ollama daemon.
+///
+/// Ollama listens on `http://localhost:11434` by default. Override
+/// with `OLLAMA_HOST` env var (matches Ollama's own convention) or
+/// [`OllamaHandler::with_host`].
+///
+/// All other capabilities fall through to `MockHandler`. Production
+/// handlers should compose with their full capability surface, not
+/// just llm.call.
+pub struct OllamaHandler {
+    host: String,
+    model: String,
+    client: ureq::Agent,
+}
+
+impl OllamaHandler {
+    /// Construct from env. `OLLAMA_HOST` defaults to
+    /// `http://localhost:11434`. Defaults model to `llama3.2:3b` —
+    /// override with [`with_model`] for your specific model tag.
+    pub fn from_env() -> Result<Self, String> {
+        let host = std::env::var("OLLAMA_HOST")
+            .unwrap_or_else(|_| "http://localhost:11434".to_string());
+        Ok(Self {
+            host,
+            model: "llama3.2:3b".to_string(),
+            client: ureq::AgentBuilder::new()
+                // Local inference can be slow; bump the timeout
+                // proportional to the largest model you serve.
+                .timeout(std::time::Duration::from_secs(300))
+                .build(),
+        })
+    }
+
+    pub fn with_host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    fn handle_llm_call(&self, args: &[Value]) -> Result<Value, String> {
+        let prompt = args
+            .first()
+            .and_then(|v| match v {
+                Value::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .ok_or_else(|| "llm.call: first arg must be a String prompt".to_string())?;
+
+        // Use the /api/generate endpoint (single-prompt completion).
+        // For multi-turn, switch to /api/chat with `messages: [...]`.
+        let body = serde_json::json!({
+            "model": self.model,
+            "prompt": prompt,
+            // Disable streaming so we get a single JSON response
+            // body the synchronous handler can return in one shot.
+            "stream": false,
+            "options": {
+                // Pin temperature for replay-friendliness.
+                "temperature": 0,
+                // Pin seed too — Ollama supports it. Removes the
+                // last source of stochasticity for replay.
+                "seed": 42,
+            },
+        });
+
+        let url = format!("{}/api/generate", self.host.trim_end_matches('/'));
+        let resp = self
+            .client
+            .post(&url)
+            .set("Content-Type", "application/json")
+            .send_json(body)
+            .map_err(|e| format!("ollama request failed: {e}"))?;
+
+        let json: serde_json::Value = resp
+            .into_json()
+            .map_err(|e| format!("ollama response parse: {e}"))?;
+        let content = json
+            .get("response")
+            .and_then(|c| c.as_str())
+            .ok_or_else(|| "ollama response missing `response` field".to_string())?;
+
+        Ok(Value::String(content.to_string()))
+    }
+}
+
+impl CapabilityHandler for OllamaHandler {
+    fn handle(&mut self, cap: &Capability, args: &[Value]) -> Result<Value, String> {
+        match cap {
+            Capability::LlmCall => self.handle_llm_call(args),
+            _ => MockHandler.handle(cap, args),
+        }
+    }
+}

--- a/examples/llm_handlers/providers.toml.example
+++ b/examples/llm_handlers/providers.toml.example
@@ -1,0 +1,66 @@
+# providers.toml — declarative LLM provider routing for Boruna
+#
+# This is a CONVENTION, not a Boruna-shipped format. The orchestrator
+# does not parse this file. The schema below is what `router_setup.rs`
+# in this directory expects, and what most BYOH integrators converge
+# on. Copy, adapt, ignore — your call.
+#
+# Goal: declare the providers your integrator supports + their
+# settings in one place, then build an `LlmRouterHandler` from it
+# at startup.
+
+# Each [providers.<name>] block registers one entry in the router.
+# The `<name>` is the dispatch key — `.ax` code calls
+# `llm_call(prompt, "<name>/<model>")` and the router dispatches on
+# the `<name>/` prefix.
+#
+# `kind` selects which handler implementation to instantiate. Add a
+# new `kind` value here when you ship a new handler in your fork.
+
+[providers.openai]
+kind = "openai"
+# `api_key_env` says which env var holds the secret. Don't put the
+# key itself in the toml — that defeats the secret-management
+# isolation BYOH gives you.
+api_key_env = "OPENAI_API_KEY"
+model = "gpt-4o-mini-2024-07-18"
+timeout_secs = 60
+
+[providers.anthropic]
+kind = "anthropic"
+api_key_env = "ANTHROPIC_API_KEY"
+# Anthropic's max_tokens is mandatory — pick the upper bound that
+# fits your longest expected response.
+model = "claude-sonnet-4-6"
+max_tokens = 4096
+timeout_secs = 60
+
+[providers.ollama-local]
+kind = "ollama"
+host = "http://localhost:11434"
+model = "llama3.2:3b"
+timeout_secs = 300
+
+[providers.openrouter]
+kind = "vllm" # OpenAI-compatible — reuse the vLLM handler
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
+model = "anthropic/claude-sonnet-4"
+timeout_secs = 120
+
+[providers.bedrock-claude-us]
+kind = "bedrock"
+# Bedrock uses the AWS credential chain — no api_key_env here.
+# AWS_REGION must be set in the env.
+model = "us.anthropic.claude-sonnet-4-5-20241022-v2:0"
+
+# Optional: declare per-provider rate limits the integrator's router
+# wrapper enforces (Boruna doesn't enforce these — it's a hook for
+# your own backoff layer).
+#
+# Format suggestion (the parser in `router_setup.rs` ignores
+# unknown keys so you can extend freely):
+#
+# [providers.openai.rate_limit]
+# requests_per_minute = 500
+# tokens_per_minute = 30_000

--- a/examples/llm_handlers/router_setup.rs
+++ b/examples/llm_handlers/router_setup.rs
@@ -1,0 +1,241 @@
+//! Reference: load `providers.toml` and build an `LlmRouterHandler`.
+//!
+//! This is a SNIPPET, not a compiled module. It demonstrates the
+//! convention `providers.toml.example` documents. Copy into your
+//! integrator crate, adapt for your handler set, and call
+//! `build_router(...)` at startup.
+//!
+//! Required deps in your fork:
+//!
+//! ```toml
+//! [dependencies]
+//! toml = "0.8"
+//! serde = { version = "1", features = ["derive"] }
+//! boruna-vm = { path = "..." }
+//! boruna-bytecode = { path = "..." }
+//! # Plus whichever provider crates the handlers you ship need.
+//! ```
+
+use std::collections::BTreeMap;
+
+use boruna_vm::capability_gateway::{CapabilityHandler, LlmRouterHandler, MockHandler};
+
+// In your fork, replace these `mod` lines with the real handler
+// modules you copy in.
+mod openai {
+    pub struct OpenAiHandler;
+    impl OpenAiHandler {
+        pub fn from_env() -> Result<Self, String> {
+            unimplemented!("paste examples/llm_handlers/openai/handler.rs")
+        }
+        pub fn with_model(self, _: impl Into<String>) -> Self {
+            self
+        }
+    }
+    impl boruna_vm::capability_gateway::CapabilityHandler for OpenAiHandler {
+        fn handle(
+            &mut self,
+            _: &boruna_bytecode::Capability,
+            _: &[boruna_bytecode::Value],
+        ) -> Result<boruna_bytecode::Value, String> {
+            unimplemented!()
+        }
+    }
+}
+mod anthropic {
+    pub struct AnthropicHandler;
+    impl AnthropicHandler {
+        pub fn from_env() -> Result<Self, String> {
+            unimplemented!("paste examples/llm_handlers/anthropic/handler.rs")
+        }
+        pub fn with_model(self, _: impl Into<String>) -> Self {
+            self
+        }
+        pub fn with_max_tokens(self, _: u32) -> Self {
+            self
+        }
+    }
+    impl boruna_vm::capability_gateway::CapabilityHandler for AnthropicHandler {
+        fn handle(
+            &mut self,
+            _: &boruna_bytecode::Capability,
+            _: &[boruna_bytecode::Value],
+        ) -> Result<boruna_bytecode::Value, String> {
+            unimplemented!()
+        }
+    }
+}
+mod ollama {
+    pub struct OllamaHandler;
+    impl OllamaHandler {
+        pub fn from_env() -> Result<Self, String> {
+            unimplemented!("paste examples/llm_handlers/ollama/handler.rs")
+        }
+        pub fn with_host(self, _: impl Into<String>) -> Self {
+            self
+        }
+        pub fn with_model(self, _: impl Into<String>) -> Self {
+            self
+        }
+    }
+    impl boruna_vm::capability_gateway::CapabilityHandler for OllamaHandler {
+        fn handle(
+            &mut self,
+            _: &boruna_bytecode::Capability,
+            _: &[boruna_bytecode::Value],
+        ) -> Result<boruna_bytecode::Value, String> {
+            unimplemented!()
+        }
+    }
+}
+mod vllm {
+    pub struct VllmHandler;
+    impl VllmHandler {
+        pub fn from_env() -> Result<Self, String> {
+            unimplemented!("paste examples/llm_handlers/vllm/handler.rs")
+        }
+        pub fn with_model(self, _: impl Into<String>) -> Self {
+            self
+        }
+        pub fn with_api_key(self, _: impl Into<String>) -> Self {
+            self
+        }
+    }
+    impl boruna_vm::capability_gateway::CapabilityHandler for VllmHandler {
+        fn handle(
+            &mut self,
+            _: &boruna_bytecode::Capability,
+            _: &[boruna_bytecode::Value],
+        ) -> Result<boruna_bytecode::Value, String> {
+            unimplemented!()
+        }
+    }
+}
+
+// Suggested toml shape — matches `providers.toml.example`. Unknown
+// keys (e.g. `rate_limit` sub-tables) are ignored at parse time so
+// integrators can extend the file without forking the parser.
+#[derive(Debug, serde::Deserialize)]
+struct ProvidersConfig {
+    providers: BTreeMap<String, ProviderEntry>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ProviderEntry {
+    kind: String,
+    /// Env var name holding the API key. None for handlers that
+    /// don't need auth (Ollama, self-hosted vLLM without auth).
+    api_key_env: Option<String>,
+    /// Endpoint override — used by `kind = "ollama"` (`host`) and
+    /// `kind = "vllm"` (`base_url`). The toml shape uses two
+    /// different keys for clarity in config; we accept either here.
+    #[serde(default)]
+    host: Option<String>,
+    #[serde(default)]
+    base_url: Option<String>,
+    model: Option<String>,
+    #[serde(default)]
+    max_tokens: Option<u32>,
+    // (timeout_secs is read but not propagated in this skeleton —
+    // each handler's `from_env` constructs its own ureq client. In
+    // your fork, add `with_timeout_secs(...)` builders to each
+    // handler if you want declarative timeouts.)
+}
+
+/// Parse `providers.toml` content and build an `LlmRouterHandler`
+/// with one entry per `[providers.*]` block. Unknown `kind`s
+/// surface as an `Err` rather than a silent skip — prevents an
+/// operator from believing their `kind = "anthropci"` typo is
+/// being honored.
+pub fn build_router(toml_text: &str) -> Result<LlmRouterHandler, String> {
+    let cfg: ProvidersConfig = toml::from_str(toml_text)
+        .map_err(|e| format!("providers.toml parse error: {e}"))?;
+
+    let mut providers: BTreeMap<String, Box<dyn CapabilityHandler>> = BTreeMap::new();
+    for (name, entry) in cfg.providers {
+        // Resolve the api key from the named env var (if any). We
+        // do this here rather than in each handler's `from_env` so
+        // the toml controls *which* env var to read; this matters
+        // when an integrator runs two openai-compatible providers
+        // with different keys (e.g. an OpenAI account + an
+        // OpenRouter account).
+        let api_key = entry.api_key_env.as_ref().and_then(|var| {
+            std::env::var(var).ok()
+        });
+
+        let handler: Box<dyn CapabilityHandler> = match entry.kind.as_str() {
+            "openai" => {
+                let mut h = openai::OpenAiHandler::from_env()?;
+                if let Some(m) = entry.model {
+                    h = h.with_model(m);
+                }
+                let _ = api_key; // OpenAI handler reads OPENAI_API_KEY internally
+                Box::new(h)
+            }
+            "anthropic" => {
+                let mut h = anthropic::AnthropicHandler::from_env()?;
+                if let Some(m) = entry.model {
+                    h = h.with_model(m);
+                }
+                if let Some(mt) = entry.max_tokens {
+                    h = h.with_max_tokens(mt);
+                }
+                Box::new(h)
+            }
+            "ollama" => {
+                let mut h = ollama::OllamaHandler::from_env()?;
+                if let Some(host) = entry.host.or(entry.base_url) {
+                    h = h.with_host(host);
+                }
+                if let Some(m) = entry.model {
+                    h = h.with_model(m);
+                }
+                Box::new(h)
+            }
+            "vllm" => {
+                // VLLM_BASE_URL must be set in env for from_env;
+                // if the toml provides base_url, set it in the env
+                // before calling from_env, OR build with a builder
+                // method. (Keeping this skeleton simple: assume env.)
+                let mut h = vllm::VllmHandler::from_env()?;
+                if let Some(m) = entry.model {
+                    h = h.with_model(m);
+                }
+                if let Some(k) = api_key {
+                    h = h.with_api_key(k);
+                }
+                Box::new(h)
+            }
+            "bedrock" => {
+                // Bedrock skeleton requires the AWS SDK — see
+                // examples/llm_handlers/bedrock/handler.rs. This
+                // branch is a placeholder; in your fork, paste the
+                // real handler in and instantiate it here.
+                return Err(format!(
+                    "kind = \"bedrock\" requires the AWS SDK; see \
+                     examples/llm_handlers/bedrock/README.md"
+                ));
+            }
+            other => {
+                return Err(format!(
+                    "unknown provider kind '{other}' for entry '{name}' \
+                     (known: openai, anthropic, ollama, vllm, bedrock)"
+                ));
+            }
+        };
+        providers.insert(name, handler);
+    }
+
+    Ok(LlmRouterHandler::new(providers, Box::new(MockHandler)))
+}
+
+// In your binary's main():
+//
+// fn main() -> Result<(), Box<dyn std::error::Error>> {
+//     let toml_text = std::fs::read_to_string("providers.toml")?;
+//     let router = build_router(&toml_text)?;
+//     let runner = boruna_orchestrator::WorkflowRunner::new(/* ... */)
+//         .with_handler(Box::new(router));
+//     runner.run()?;
+//     Ok(())
+// }

--- a/examples/llm_handlers/vllm/README.md
+++ b/examples/llm_handlers/vllm/README.md
@@ -1,0 +1,72 @@
+# vLLM (and OpenAI-compatible) LLM Handler — Reference Example
+
+Reference implementation of a `CapabilityHandler` that routes `llm.call` to any **OpenAI-compatible** chat-completions endpoint. Use this for:
+
+- **vLLM** — self-hosted, GPU-backed
+- **OpenRouter** — managed multi-model proxy
+- **Together AI / Groq / Fireworks** — managed inference
+- **LiteLLM proxy** — your own routing layer
+- **SGLang** — self-hosted, structured-output capable
+
+**Reference only — not a production handler.** See [`docs/guides/llm-integration.md`](../../../docs/guides/llm-integration.md) for the BYOH integration model.
+
+## Why have this separate from the OpenAI handler?
+
+The wire shape is identical (vLLM, OpenRouter, et al. mimic OpenAI's Chat Completions). The differences this handler makes explicit:
+
+- **Configurable base URL** via `VLLM_BASE_URL`. The OpenAI handler is hardcoded to `https://api.openai.com/v1`.
+- **Optional auth.** Self-hosted vLLM typically runs without an API key; managed proxies require one. The handler accepts both.
+- **No safe default model.** Each endpoint serves its own catalog; you must call `.with_model("...")` explicitly.
+
+If you're pointing Boruna at OpenAI itself, prefer the [OpenAI example](../openai/) — its API-key-required signature avoids accidental anonymous calls.
+
+## Files
+
+- `handler.rs` — the `VllmHandler` struct and its `CapabilityHandler` impl.
+
+## Configuration
+
+| Variable | Required? | Example |
+|---|---|---|
+| `VLLM_BASE_URL` | yes | `http://localhost:8000/v1`, `https://openrouter.ai/api/v1`, `https://api.together.xyz/v1` |
+| `VLLM_API_KEY` | optional | required by managed proxies; not by self-hosted vLLM |
+| (model) | required (programmatic) | call `.with_model("meta-llama/Llama-3-70b-Instruct")` etc. |
+
+## Setup examples
+
+**Self-hosted vLLM:**
+
+```bash
+# vLLM listens on port 8000 by default
+vllm serve meta-llama/Llama-3.1-8B-Instruct
+export VLLM_BASE_URL=http://localhost:8000/v1
+# No API key needed
+```
+
+**OpenRouter:**
+
+```bash
+export VLLM_BASE_URL=https://openrouter.ai/api/v1
+export VLLM_API_KEY=sk-or-v1-...
+# Then .with_model("anthropic/claude-sonnet-4") etc.
+```
+
+**Together AI:**
+
+```bash
+export VLLM_BASE_URL=https://api.together.xyz/v1
+export VLLM_API_KEY=...
+# Then .with_model("meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo")
+```
+
+## What it doesn't do
+
+- **Multi-provider routing.** Single endpoint per handler. See `examples/llm_handlers/router_setup.rs` to compose multiple `VllmHandler` instances under `LlmRouterHandler`.
+- **Streaming.** Boruna's capability calls are synchronous.
+- **Provider-specific extensions.** vLLM has guided-decoding parameters (`guided_json`, `guided_regex`) that the OpenAI shape doesn't carry. If you depend on those, extend the request `body` JSON in your fork.
+
+## Determinism
+
+Same posture as the OpenAI handler: `temperature: 0` (set by default). If you serve through vLLM directly, also pin `seed` in the request body. For managed proxies, determinism depends on the underlying model serving stack — read your proxy's docs.
+
+See [`docs/guides/llm-integration.md`](../../../docs/guides/llm-integration.md) for the full discussion.

--- a/examples/llm_handlers/vllm/handler.rs
+++ b/examples/llm_handlers/vllm/handler.rs
@@ -1,0 +1,119 @@
+//! Reference `CapabilityHandler` impl for vLLM (and any other
+//! OpenAI-compatible endpoint: OpenRouter, Together, Groq,
+//! self-hosted SGLang, LiteLLM proxy, etc.).
+//!
+//! This is a reference for the BYOH integration pattern documented in
+//! `docs/guides/llm-integration.md` — NOT a production handler.
+
+use boruna_bytecode::{Capability, Value};
+use boruna_vm::capability_gateway::{CapabilityHandler, MockHandler};
+
+/// LLM handler that routes `llm.call` to a vLLM (or any other
+/// OpenAI-compatible) endpoint.
+///
+/// **The wire shape is identical to the OpenAI handler;** the only
+/// real differences are the base URL and that the API key may be
+/// optional (self-hosted vLLM often runs without auth). If you're
+/// pointing at OpenAI itself, prefer the dedicated `openai/` example.
+///
+/// All other capabilities fall through to `MockHandler`.
+pub struct VllmHandler {
+    base_url: String,
+    api_key: Option<String>,
+    model: String,
+    client: ureq::Agent,
+}
+
+impl VllmHandler {
+    /// Construct from env. `VLLM_BASE_URL` is required (e.g.
+    /// `http://localhost:8000/v1` for a local vLLM, or
+    /// `https://openrouter.ai/api/v1` for OpenRouter).
+    /// `VLLM_API_KEY` is optional — set when the endpoint requires
+    /// auth (most managed proxies do; self-hosted vLLM does not by
+    /// default).
+    pub fn from_env() -> Result<Self, String> {
+        let base_url = std::env::var("VLLM_BASE_URL")
+            .map_err(|_| "VLLM_BASE_URL not set (e.g. http://localhost:8000/v1)".to_string())?;
+        let api_key = std::env::var("VLLM_API_KEY").ok();
+        Ok(Self {
+            base_url,
+            api_key,
+            // No safe default — the operator must specify the model
+            // their endpoint actually serves. Fail loudly via the
+            // upstream 404 if the caller forgets.
+            model: String::new(),
+            client: ureq::AgentBuilder::new()
+                .timeout(std::time::Duration::from_secs(120))
+                .build(),
+        })
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_api_key(mut self, key: impl Into<String>) -> Self {
+        self.api_key = Some(key.into());
+        self
+    }
+
+    fn handle_llm_call(&self, args: &[Value]) -> Result<Value, String> {
+        if self.model.is_empty() {
+            return Err("vllm: no model configured; call .with_model(...)".into());
+        }
+
+        let prompt = args
+            .first()
+            .and_then(|v| match v {
+                Value::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .ok_or_else(|| "llm.call: first arg must be a String prompt".to_string())?;
+
+        let body = serde_json::json!({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+        });
+
+        let url = format!(
+            "{}/chat/completions",
+            self.base_url.trim_end_matches('/')
+        );
+        let mut req = self
+            .client
+            .post(&url)
+            .set("Content-Type", "application/json");
+        if let Some(ref key) = self.api_key {
+            req = req.set("Authorization", &format!("Bearer {key}"));
+        }
+        let resp = req
+            .send_json(body)
+            .map_err(|e| format!("vllm request failed: {e}"))?;
+
+        let json: serde_json::Value = resp
+            .into_json()
+            .map_err(|e| format!("vllm response parse: {e}"))?;
+        // OpenAI-compatible response shape — same path as the OpenAI
+        // handler.
+        let content = json
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("message"))
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .ok_or_else(|| "vllm response missing choices[0].message.content".to_string())?;
+
+        Ok(Value::String(content.to_string()))
+    }
+}
+
+impl CapabilityHandler for VllmHandler {
+    fn handle(&mut self, cap: &Capability, args: &[Value]) -> Result<Value, String> {
+        match cap {
+            Capability::LlmCall => self.handle_llm_call(args),
+            _ => MockHandler.handle(cap, args),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reframe of T-1.2 from the original "ship a `boruna-effect-providers` adapter crate" plan to a **BYOH-faithful** expansion of the existing reference-handler library.

Per Convention §40 ("Audit retro premises before committing scope"), the original T-1.2 plan was audited against the shipped BYOH design contract (`docs/guides/llm-integration.md`, sprint 0.3-S8) before any code was written. The original plan would have directly violated the documented "Boruna does not ship default LLM handlers" principle. Reframed scope delivers the spirit of "more provider on-ramps" without the contract violation. User chose this option (A) over skipping (B) or rolling back BYOH (C).

## What lands

Five reference handlers under `examples/llm_handlers/`:

| Provider | Path | Notes |
|---|---|---|
| OpenAI | (existing) `openai/` | unchanged baseline |
| Anthropic | `anthropic/` | Messages API, x-api-key auth, content[0].text response |
| Ollama | `ollama/` | local-LLM with seed for deterministic replay |
| vLLM (and OpenAI-compat) | `vllm/` | covers vLLM/OpenRouter/Together/Groq/LiteLLM in one shape |
| AWS Bedrock | `bedrock/` | skeleton using AWS SDK (SigV4 hand-roll wasn't illustrative); shows Anthropic-on-Bedrock body shape with notes for Llama/Titan/Mistral/Cohere |

Plus:
- `examples/llm_handlers/README.md` — umbrella index linking all five handlers + the `LlmRouterHandler` primitive
- `examples/llm_handlers/providers.toml.example` — documented config-schema *convention* (Boruna does not parse this; integrators choose to adopt)
- `examples/llm_handlers/router_setup.rs` — reference parser turning the toml into an `LlmRouterHandler`
- Updated `docs/guides/llm-integration.md` "Provider variants" section to link all five (was OpenAI-only)
- CHANGELOG `### Added` entry with the audit + reframe rationale

## Shape mirrors the existing OpenAI reference

Each handler is a self-contained 80–120 LOC copy-and-tweak template. **No Cargo.toml** — integrators paste `handler.rs` into their own crate. Same posture the existing `openai/handler.rs` already takes.

Each README documents per-provider gotchas (auth header, response path, determinism options, model defaults) and what the reference deliberately omits (multi-provider routing, streaming, cost accounting, secret rotation).

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Note: the examples are uncompiled reference snippets (no Cargo.toml) — they don't appear in the workspace gates. This matches the existing `openai/` reference's posture. Integrators get type-checking when they paste into their own crate.

## Known infra debt

Bench-compare CI will fail with `gh: command not found` on the self-hosted runner. Same pre-existing operator follow-up (#26/#29/#30/#31/#32 all hit it); admin-merge past it.

## Audit trail

The original T-1.2 plan from `post-1.0-execution-status` memory:

> T-1.2 LLM provider registry. Heavyweight: new `boruna-effect-providers` workspace crate with OpenAI/Anthropic/Bedrock adapters, wiremock-based mocks, integration-test feature gates, per-provider rate limits.

Conflicts directly with `docs/guides/llm-integration.md:3`:

> Boruna does **not** ship a default LLM handler. The supported integration model is **Bring Your Own Handler (BYOH)**.

And the explicit "convenience CLI handler was considered and **rejected**" line. Catching this before writing 1000+ LOC of soon-to-be-rejected adapter code is exactly what Convention §40 ("Audit retro premises before committing scope") is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)