### PR TITLE
ci(bench-compare): replace `gh` calls with curl + jq

### DIFF
--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -106,26 +106,75 @@ jobs:
 
       - name: Post sticky comment
         env:
+          # All untrusted PR-context values are funneled through env
+          # vars (per GitHub workflow-injection guidance). The
+          # existing PR number + repo slug are GitHub-controlled
+          # numerics/identifiers, not attacker-controllable strings.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Body lives on disk; never interpolated through shell.
+          # Use curl + jq instead of `gh` — the self-hosted runner
+          # does not have the `gh` CLI installed (operator follow-up
+          # tracked in post-1.0-execution-status memory). curl + jq
+          # are standard on any Linux runner. The body lives on
+          # disk and is JSON-encoded by jq -Rs; never interpolated
+          # through shell.
           MARKER='<!-- bench-compare:sticky -->'
           {
             printf '%s\n' "$MARKER"
             cat comment.md
           } > body.md
-          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
+
+          api() {
+            # Wrapper: standard GitHub REST headers + bearer auth +
+            # fail-on-error. $1 = method, $2 = path-after-/repos.
+            # Optional stdin = JSON body (for non-GET).
+            local method="$1"
+            local path="$2"
+            local url="https://api.github.com/${path}"
+            if [ "$method" = GET ]; then
+              curl -fsSL \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "$url"
+            else
+              curl -fsSL -X "$method" \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -H "Content-Type: application/json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                --data-binary @- \
+                "$url"
+            fi
+          }
+
+          # Find the existing sticky comment (if any) by marker
+          # prefix. --arg passes MARKER as a jq variable; never
+          # shell-interpolated into the jq script.
+          existing=$(api GET "repos/$REPO/issues/$PR_NUMBER/comments" \
+            | jq -r --arg marker "$MARKER" \
+                '.[] | select(.body | startswith($marker)) | .id' \
             | head -1)
+
+          # Build a {"body": "..."} JSON payload from body.md.
+          # jq -Rs reads the file as one raw string and properly
+          # escapes newlines, quotes, and any other JSON-significant
+          # chars — safer than shell-quoting comment.md.
+          payload=$(jq -Rs '{body: .}' < body.md)
+
           if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
-              -F body=@body.md > /dev/null
+            # `existing` is a numeric comment ID returned by GitHub —
+            # not an attacker-controllable string. Safe to interp.
+            printf '%s' "$payload" \
+              | api PATCH "repos/$REPO/issues/comments/$existing" \
+              > /dev/null
           else
-            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
-              -F body=@body.md > /dev/null
+            printf '%s' "$payload" \
+              | api POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              > /dev/null
           fi
 
       - name: Fail on regression


### PR DESCRIPTION
## Summary

The bench-compare workflow has been failing on **every PR** (#26 / #29 / #30 / #31 / #32 / #33) on the "Post sticky comment" step with `gh: command not found`. The self-hosted runner does not have the `gh` CLI installed and that's been an outstanding operator follow-up — but the same job can be done with `curl` + `jq`, which are present on every Linux runner by default.

## Changes

`.github/workflows/bench-compare.yml` — "Post sticky comment" step:

- Replace three `gh api` calls (GET-list / PATCH-update / POST-create) with equivalent `curl` invocations against the GitHub REST API.
- Add a small `api()` shell wrapper that bundles the standard headers (`Authorization: Bearer`, `Accept: application/vnd.github+json`, `X-GitHub-Api-Version: 2022-11-28`) and `-fsSL` so HTTP errors fail the step.
- Marker-finding jq pipeline is unchanged (still uses `--arg marker`; MARKER is never shell-interpolated into the jq script).
- Body construction now uses `jq -Rs '{body: .}' < body.md`, which produces a properly JSON-escaped `{"body": "..."}` payload — safer than any shell-quoting attempt.

## Local validation

End-to-end tested with a stub `curl` simulating both code paths:

- **Existing-comment branch** (sticky id=1002 found): GET → PATCH `/repos/.../issues/comments/1002` with correct payload. Exit 0.
- **New-comment branch** (no sticky): GET → POST `/repos/.../issues/<PR>/comments` with correct payload. Exit 0.

Both payloads JSON-encoded correctly, including newlines and special chars (`$`, `"`).

## Why a separate PR

Independent concern from any feature work; benefits every subsequent PR. Note: this PR's own bench-compare run will still use the OLD (broken) workflow because GitHub Actions evaluates `pull_request` workflows from the base branch (master) — so this PR will hit the same failure pattern. Admin-merge past it as established practice; subsequent PRs will exercise the new workflow.

## Test plan

- [x] `bash -n` — script syntax clean
- [x] End-to-end mock test (stub curl) — both PATCH and POST branches produce correct API calls + JSON payloads
- [ ] Real-world verification — first PR opened AFTER this lands on master will exercise the new workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)