### PR TITLE
feat(post1-T-2.2): capability call markers in MCP progress notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Capability call markers in MCP progress notifications** (post1-T-2.2).
+  `boruna_run` streaming progress events now carry a `message` field when
+  a capability call fires during an execution slice: `"cap: llm.call"` for
+  a single call or `"caps: llm.call, net.fetch"` for multiple. Slices with
+  no capability calls continue to omit `message` (no noise for pure compute).
+  MCP clients that display live execution status can now surface `"calling
+  llm.call…"` feedback without polling. Backward-compatible: existing clients
+  that ignore `message` see no change.
+
 - **BYOH reference handler library** (post1-T-1.2). Four new
   reference `CapabilityHandler` implementations under
   `examples/llm_handlers/` joining the existing OpenAI example:

--- a/crates/boruna-mcp/src/server.rs
+++ b/crates/boruna-mcp/src/server.rs
@@ -239,11 +239,11 @@ impl BorunaMcpServer {
             // 100 by default), so the queue is shallow and a bounded
             // channel adds backpressure complexity for no real benefit.
             // If max_steps grew unboundedly this would need revisiting.
-            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<u64>();
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(u64, Option<String>)>();
             let peer = ctx.peer.clone();
             let token_clone = token.clone();
             let forwarder = tokio::spawn(async move {
-                while let Some(steps) = rx.recv().await {
+                while let Some((steps, message)) = rx.recv().await {
                     // Best-effort delivery: a notify failure (e.g. the
                     // client disconnected mid-run) is logged-and-
                     // continued. The VM keeps running and will surface
@@ -255,12 +255,15 @@ impl BorunaMcpServer {
                     // well under the cap. With None, MCP clients
                     // treat `progress` as a monotonic count without a
                     // percentage interpretation. Reviewed in 0.4-S6.
+                    // T-2.2: `message` carries capability call markers
+                    // ("cap: llm.call", "caps: llm.call, net.fetch") so
+                    // MCP clients can surface live capability activity.
                     let _ = peer
                         .notify_progress(ProgressNotificationParam {
                             progress_token: token_clone.clone(),
                             progress: steps as f64,
                             total: None,
-                            message: None,
+                            message,
                         })
                         .await;
                 }
@@ -274,13 +277,13 @@ impl BorunaMcpServer {
                     trace,
                     limits.as_ref(),
                     output_schema.as_ref(),
-                    Some(move |steps: u64| {
+                    Some(move |steps: u64, message: Option<String>| {
                         // Channel is closed only after the blocking
                         // task drops its sender, which happens after
                         // run_source_with_progress returns. Send
                         // failures here are unreachable in practice
                         // but ignored if they ever occur.
-                        let _ = tx.send(steps);
+                        let _ = tx.send((steps, message));
                     }),
                 )
             })

--- a/crates/boruna-mcp/src/tools/run.rs
+++ b/crates/boruna-mcp/src/tools/run.rs
@@ -1142,7 +1142,11 @@ fn main() -> Int {
             }),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(parsed["success"], json!(true), "program must succeed: {out}");
+        assert_eq!(
+            parsed["success"],
+            json!(true),
+            "program must succeed: {out}"
+        );
 
         let msgs = messages.lock().unwrap();
         // Some notifications may fire; all must have message = None (no caps called).

--- a/crates/boruna-mcp/src/tools/run.rs
+++ b/crates/boruna-mcp/src/tools/run.rs
@@ -87,7 +87,7 @@ pub fn run_source(
         trace,
         limits,
         output_schema,
-        None::<fn(u64)>,
+        None::<fn(u64, Option<String>)>,
     )
 }
 
@@ -120,7 +120,7 @@ pub fn run_source_with_progress<F>(
     progress_callback: Option<F>,
 ) -> String
 where
-    F: FnMut(u64),
+    F: FnMut(u64, Option<String>),
 {
     // Reject unsupported limits BEFORE compiling, so an integrator who
     // misconfigures (e.g. sets max_memory_mb expecting it to bound memory)
@@ -277,7 +277,7 @@ where
 ///    than resetting per slice.
 fn drive_vm<F>(vm: &mut Vm, mut progress_callback: Option<F>) -> Result<Value, VmError>
 where
-    F: FnMut(u64),
+    F: FnMut(u64, Option<String>),
 {
     if progress_callback.is_none() {
         // Fast path: no progress callback. Use the existing `vm.run()`
@@ -297,7 +297,17 @@ where
             StepResult::Completed(val) => return Ok(val),
             StepResult::Yielded { .. } => {
                 if let Some(cb) = progress_callback.as_mut() {
-                    cb(vm.step_count());
+                    // T-2.2: drain capability calls made in this slice and
+                    // format as a message for the MCP progress notification.
+                    let caps = vm.take_last_cap_events();
+                    let message = if caps.is_empty() {
+                        None
+                    } else if caps.len() == 1 {
+                        Some(format!("cap: {}", caps[0]))
+                    } else {
+                        Some(format!("caps: {}", caps.join(", ")))
+                    };
+                    cb(vm.step_count(), message);
                 }
             }
             // `Blocked` cannot arise from `Op::ReceiveMsg` here:
@@ -957,7 +967,7 @@ fn main() -> Int {
             false,
             None,
             None,
-            Some(move |steps: u64| {
+            Some(move |steps: u64, _message: Option<String>| {
                 samples_clone.lock().unwrap().push(steps);
             }),
         );
@@ -1004,7 +1014,7 @@ fn main() -> Int {
             false,
             None,
             None,
-            None::<fn(u64)>,
+            None::<fn(u64, Option<String>)>,
         );
         assert_eq!(
             legacy, streamed,
@@ -1029,7 +1039,7 @@ fn main() -> Int {
             false,
             None,
             None,
-            Some(move |steps: u64| {
+            Some(move |steps: u64, _message: Option<String>| {
                 samples_clone.lock().unwrap().push(steps);
             }),
         );
@@ -1070,7 +1080,7 @@ fn main() -> Int {
             false,
             None,
             None,
-            Some(|_steps: u64| {}),
+            Some(|_steps: u64, _message: Option<String>| {}),
         );
         // Both paths must succeed with the same result. The exact step
         // count may differ trivially (start_timer placement); compare
@@ -1101,10 +1111,45 @@ fn main() -> Int {
             false,
             None,
             None,
-            Some(|_steps: u64| {}),
+            Some(|_steps: u64, _message: Option<String>| {}),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["success"], json!(false));
         assert_eq!(parsed["error_kind"], json!("runtime_error"));
+    }
+
+    // ── T-2.2: capability_call streaming events ──
+    // The cap-name-in-message contract is tested at the VM level
+    // (boruna-vm crate) where bytecode can be injected directly.
+    // Here we test only the pure-program case to lock the MCP-layer
+    // contract: no cap calls → message is always None.
+
+    #[test]
+    fn progress_callback_message_is_none_when_no_caps_called() {
+        use std::sync::{Arc, Mutex};
+        let messages: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
+        let messages_clone = Arc::clone(&messages);
+        // STREAMING_PROGRAM is a pure while-loop with no capability calls.
+        let out = run_source_with_progress(
+            STREAMING_PROGRAM,
+            None,
+            10_000_000,
+            false,
+            None,
+            None,
+            Some(move |_steps: u64, message: Option<String>| {
+                messages_clone.lock().unwrap().push(message);
+            }),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["success"], json!(true), "program must succeed: {out}");
+
+        let msgs = messages.lock().unwrap();
+        // Some notifications may fire; all must have message = None (no caps called).
+        assert!(
+            msgs.iter().all(|m| m.is_none()),
+            "pure program must never emit cap messages: {:?}",
+            msgs
+        );
     }
 }

--- a/crates/llmvm/src/tests.rs
+++ b/crates/llmvm/src/tests.rs
@@ -2002,4 +2002,53 @@ mod tests {
         let err = VmError::MaxRoundsExceeded(100);
         assert_eq!(format!("{err}"), "max scheduler rounds exceeded (100)");
     }
+
+    // ── T-2.2: last_cap_events tracking ──
+
+    #[test]
+    fn test_take_last_cap_events_records_cap_name() {
+        // A one-shot CapCall (time.now, id=5) followed by Ret.
+        // After vm.run(), last_cap_events should have been populated
+        // and be drainable via take_last_cap_events.
+        let module = simple_module(
+            vec![Op::CapCall(5, 0), Op::Ret], // time.now, no args
+            vec![],
+        );
+        let gateway = CapabilityGateway::new(Policy::allow_all());
+        let mut vm = Vm::new(module, gateway);
+        vm.run().expect("should succeed");
+        let events = vm.take_last_cap_events();
+        assert_eq!(events, vec!["time.now"], "cap name must be recorded");
+    }
+
+    #[test]
+    fn test_take_last_cap_events_clears_on_drain() {
+        let module = simple_module(
+            vec![Op::CapCall(5, 0), Op::Ret],
+            vec![],
+        );
+        let gateway = CapabilityGateway::new(Policy::allow_all());
+        let mut vm = Vm::new(module, gateway);
+        vm.run().expect("should succeed");
+        let _ = vm.take_last_cap_events();
+        assert!(
+            vm.take_last_cap_events().is_empty(),
+            "second drain must return empty"
+        );
+    }
+
+    #[test]
+    fn test_take_last_cap_events_empty_for_pure_program() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::Ret],
+            vec![Value::Int(42)],
+        );
+        let gateway = CapabilityGateway::new(Policy::allow_all());
+        let mut vm = Vm::new(module, gateway);
+        vm.run().expect("should succeed");
+        assert!(
+            vm.take_last_cap_events().is_empty(),
+            "pure program must leave cap events empty"
+        );
+    }
 }

--- a/crates/llmvm/src/tests.rs
+++ b/crates/llmvm/src/tests.rs
@@ -2023,10 +2023,7 @@ mod tests {
 
     #[test]
     fn test_take_last_cap_events_clears_on_drain() {
-        let module = simple_module(
-            vec![Op::CapCall(5, 0), Op::Ret],
-            vec![],
-        );
+        let module = simple_module(vec![Op::CapCall(5, 0), Op::Ret], vec![]);
         let gateway = CapabilityGateway::new(Policy::allow_all());
         let mut vm = Vm::new(module, gateway);
         vm.run().expect("should succeed");
@@ -2039,10 +2036,7 @@ mod tests {
 
     #[test]
     fn test_take_last_cap_events_empty_for_pure_program() {
-        let module = simple_module(
-            vec![Op::PushConst(0), Op::Ret],
-            vec![Value::Int(42)],
-        );
+        let module = simple_module(vec![Op::PushConst(0), Op::Ret], vec![Value::Int(42)]);
         let gateway = CapabilityGateway::new(Policy::allow_all());
         let mut vm = Vm::new(module, gateway);
         vm.run().expect("should succeed");

--- a/crates/llmvm/src/vm.rs
+++ b/crates/llmvm/src/vm.rs
@@ -65,6 +65,9 @@ pub struct Vm {
     /// Trace log for debugging.
     pub trace: Vec<String>,
     pub trace_enabled: bool,
+    /// Capability calls made during the current execute_bounded slice.
+    /// Drained by `take_last_cap_events` between slices (T-2.2).
+    last_cap_events: Vec<&'static str>,
     // --- Actor fields ---
     /// Which actor this VM belongs to (0 = root/default).
     actor_id: u64,
@@ -115,6 +118,7 @@ impl Vm {
             ui_output: Vec::new(),
             trace: Vec::new(),
             trace_enabled: false,
+            last_cap_events: Vec::new(),
             actor_id: 0,
             mailbox: VecDeque::new(),
             outgoing_messages: Vec::new(),
@@ -148,6 +152,13 @@ impl Vm {
         if self.start_time.is_none() {
             self.start_time = Some(Instant::now());
         }
+    }
+
+    /// Drain capability call names accumulated since the last call (T-2.2).
+    /// Called between execute_bounded slices to surface cap events in
+    /// MCP progress notifications.
+    pub fn take_last_cap_events(&mut self) -> Vec<&'static str> {
+        std::mem::take(&mut self.last_cap_events)
     }
 
     pub fn set_max_steps(&mut self, max: u64) {
@@ -584,6 +595,7 @@ impl Vm {
                     args.reverse();
 
                     let result = self.gateway.call(&cap, &args, &mut self.event_log)?;
+                    self.last_cap_events.push(cap.name());
                     self.push(result)?;
                 }
                 Op::Add => self.binary_op(|a, b| match (a, b) {


### PR DESCRIPTION
## Summary

- Adds `message:` field to `notifications/progress` events during `boruna_run` streaming execution
- When an `Op::CapCall` fires within a 100k-step slice, the capability name is surfaced: `"cap: llm.call"` (single) or `"caps: llm.call, net.fetch"` (multiple)
- Slices with no capability calls emit no message (backward-compatible)
- MCP clients can now display "calling llm.call…" live feedback during streaming runs

## Implementation

- `Vm::last_cap_events: Vec<&'static str>` — accumulates cap names per bounded slice; drained by `take_last_cap_events()` between slices
- `drive_vm` callback signature: `FnMut(u64, Option<String>)` (was `FnMut(u64)`)
- MCP unbounded channel: `(u64, Option<String>)` (was `u64`)
- `ProgressNotificationParam::message` populated from drained events

## Test plan

- [ ] 3 VM-level tests: `take_last_cap_events` records cap name, clears on second drain, empty for pure program
- [ ] 1 MCP-level test: pure program always sends `message: None`
- [ ] Existing streaming progress tests unchanged (callback signature updated in-place)
- [ ] `cargo test -p boruna-vm -p boruna-mcp` — all pass
- [ ] `cargo clippy -p boruna-vm -p boruna-mcp -- -D warnings` — clean

Resolves post1-T-2.2. Reframes original plan (custom event format) as additive `message:` field on the MCP-standard `notifications/progress` channel from T-1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)