### PR TITLE
feat(post1-T-4.3): mTLS OCSP stapling on 0.7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added (0.7.x speculative)
 
+- `boruna coordinator serve --tls-ocsp-staple <FILE>` (post1-T-4.3)
+  staples a pre-fetched DER-encoded OCSP response into every TLS
+  handshake via rustls's `with_single_cert_with_ocsp`. Clients
+  receive revocation proof inline without a separate OCSP round-trip.
+  Requires the full mTLS trio; file is read at startup (fail-fast).
+  See `docs/guides/mtls-crl.md` for the generation recipe.
+  **0.7.x-only** feature: not part of the 1.x LTS surface.
+
 - `boruna coordinator serve --tls-client-crl <FILE>` (post1-T-4.2)
   loads PEM-encoded X509 CRLs at startup and feeds them to
   rustls's `WebPkiClientVerifier::with_crls`. Connections from

--- a/crates/llmvm-cli/src/coordinator.rs
+++ b/crates/llmvm-cli/src/coordinator.rs
@@ -3751,9 +3751,11 @@ mod tests {
     #[test]
     fn parse_tls_flags_requires_all_three_or_none() {
         // None of the three flags = no TLS, ok.
-        assert!(ServerTlsPaths::from_optional(None, None, None, vec![], None)
-            .unwrap()
-            .is_none());
+        assert!(
+            ServerTlsPaths::from_optional(None, None, None, vec![], None)
+                .unwrap()
+                .is_none()
+        );
         // All three present = ok.
         let p = std::path::PathBuf::from("/tmp/x");
         let triple = ServerTlsPaths::from_optional(
@@ -3789,8 +3791,7 @@ mod tests {
         // plaintext server, so silently dropping it would be a
         // dangerous footgun.
         let crl = std::path::PathBuf::from("/tmp/some.crl");
-        let err =
-            ServerTlsPaths::from_optional(None, None, None, vec![crl], None).unwrap_err();
+        let err = ServerTlsPaths::from_optional(None, None, None, vec![crl], None).unwrap_err();
         assert!(err.to_string().contains("CRL"), "unexpected err: {err}");
     }
 
@@ -3800,12 +3801,9 @@ mod tests {
         // trio is a startup error. OCSP stapling requires a TLS
         // server cert to staple against.
         let staple = std::path::PathBuf::from("/tmp/server.ocsp");
-        let err = ServerTlsPaths::from_optional(None, None, None, vec![], Some(staple))
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("OCSP"),
-            "unexpected err: {err}"
-        );
+        let err =
+            ServerTlsPaths::from_optional(None, None, None, vec![], Some(staple)).unwrap_err();
+        assert!(err.to_string().contains("OCSP"), "unexpected err: {err}");
     }
 
     #[test]

--- a/crates/llmvm-cli/src/coordinator.rs
+++ b/crates/llmvm-cli/src/coordinator.rs
@@ -151,6 +151,16 @@ pub struct ServerTlsPaths {
     /// SIGHUP is documented in
     /// `docs/guides/mtls-crl.md`.
     pub crls: Vec<PathBuf>,
+    /// post1-T-4.3 (0.7.x): optional path to a DER-encoded OCSP
+    /// response to staple into the TLS handshake. When set, rustls
+    /// includes the pre-fetched response so connecting clients do
+    /// not need to perform a separate OCSP request to verify the
+    /// server cert's revocation status.
+    ///
+    /// Requires the full mTLS trio — passing an OCSP staple
+    /// without `--tls-cert/--tls-key/--tls-client-ca` is a
+    /// startup error. File must exist at startup (fail-fast).
+    pub ocsp_staple: Option<PathBuf>,
 }
 
 impl ServerTlsPaths {
@@ -159,14 +169,16 @@ impl ServerTlsPaths {
     /// triple. Mixing-and-matching (e.g. `--tls-cert` without
     /// `--tls-key`) is a startup error per project §1.
     ///
-    /// `crls` is independent — passing CRLs without the cert/key
-    /// trio is a startup error so misconfigured CRL paths don't
-    /// silently disappear into a plaintext-only server.
+    /// `crls` and `ocsp_staple` are independent extras — passing
+    /// either without the cert/key trio is a startup error so
+    /// misconfigured paths don't silently disappear into a
+    /// plaintext-only server.
     pub fn from_optional(
         cert: Option<PathBuf>,
         key: Option<PathBuf>,
         client_ca: Option<PathBuf>,
         crls: Vec<PathBuf>,
+        ocsp_staple: Option<PathBuf>,
     ) -> Result<Option<Self>, Box<dyn std::error::Error>> {
         match (cert, key, client_ca) {
             (None, None, None) => {
@@ -177,6 +189,13 @@ impl ServerTlsPaths {
                             .into(),
                     );
                 }
+                if ocsp_staple.is_some() {
+                    return Err(
+                        "--tls-ocsp-staple requires --tls-cert/--tls-key/--tls-client-ca \
+                         to be configured (OCSP stapling applies to mTLS only)"
+                            .into(),
+                    );
+                }
                 Ok(None)
             }
             (Some(cert), Some(key), Some(client_ca)) => Ok(Some(Self {
@@ -184,6 +203,7 @@ impl ServerTlsPaths {
                 key,
                 client_ca,
                 crls,
+                ocsp_staple,
             })),
             _ => Err("--tls-cert, --tls-key, --tls-client-ca must all be provided together".into()),
         }
@@ -391,10 +411,23 @@ fn build_server_tls(
         .build()
         .map_err(|e| format!("build client cert verifier: {e}"))?;
 
-    let server_config = rustls::ServerConfig::builder()
-        .with_client_cert_verifier(verifier)
-        .with_single_cert(cert_chain, key)
-        .map_err(|e| format!("rustls ServerConfig: {e}"))?;
+    // post1-T-4.3: load OCSP staple (DER-encoded) if provided and
+    // pass to rustls via with_single_cert_with_ocsp. When absent
+    // fall back to the plain with_single_cert path (no behaviour
+    // change for existing deployments).
+    let server_config = if let Some(ref staple_path) = paths.ocsp_staple {
+        let ocsp_bytes = std::fs::read(staple_path)
+            .map_err(|e| format!("read OCSP staple {}: {e}", staple_path.display()))?;
+        rustls::ServerConfig::builder()
+            .with_client_cert_verifier(verifier)
+            .with_single_cert_with_ocsp(cert_chain, key, ocsp_bytes)
+            .map_err(|e| format!("rustls ServerConfig (with OCSP staple): {e}"))?
+    } else {
+        rustls::ServerConfig::builder()
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(cert_chain, key)
+            .map_err(|e| format!("rustls ServerConfig: {e}"))?
+    };
 
     Ok(CompiledServerTls {
         config: Arc::new(server_config),
@@ -3718,7 +3751,7 @@ mod tests {
     #[test]
     fn parse_tls_flags_requires_all_three_or_none() {
         // None of the three flags = no TLS, ok.
-        assert!(ServerTlsPaths::from_optional(None, None, None, vec![])
+        assert!(ServerTlsPaths::from_optional(None, None, None, vec![], None)
             .unwrap()
             .is_none());
         // All three present = ok.
@@ -3728,6 +3761,7 @@ mod tests {
             Some(p.clone()),
             Some(p.clone()),
             vec![],
+            None,
         )
         .unwrap();
         assert!(triple.is_some());
@@ -3740,7 +3774,7 @@ mod tests {
             (Some(p.clone()), None, Some(p.clone())),
             (None, Some(p.clone()), Some(p.clone())),
         ] {
-            let err = ServerTlsPaths::from_optional(a, b, c, vec![]).unwrap_err();
+            let err = ServerTlsPaths::from_optional(a, b, c, vec![], None).unwrap_err();
             assert!(
                 err.to_string().contains("must all be provided together"),
                 "unexpected err: {err}"
@@ -3755,8 +3789,41 @@ mod tests {
         // plaintext server, so silently dropping it would be a
         // dangerous footgun.
         let crl = std::path::PathBuf::from("/tmp/some.crl");
-        let err = ServerTlsPaths::from_optional(None, None, None, vec![crl]).unwrap_err();
+        let err =
+            ServerTlsPaths::from_optional(None, None, None, vec![crl], None).unwrap_err();
         assert!(err.to_string().contains("CRL"), "unexpected err: {err}");
+    }
+
+    #[test]
+    fn parse_tls_flags_ocsp_without_mtls_rejected() {
+        // post1-T-4.3: passing --tls-ocsp-staple without the mTLS
+        // trio is a startup error. OCSP stapling requires a TLS
+        // server cert to staple against.
+        let staple = std::path::PathBuf::from("/tmp/server.ocsp");
+        let err = ServerTlsPaths::from_optional(None, None, None, vec![], Some(staple))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("OCSP"),
+            "unexpected err: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_tls_flags_ocsp_with_valid_mtls_accepted() {
+        // post1-T-4.3: OCSP staple path is stored when all three
+        // TLS flags are also provided.
+        let p = std::path::PathBuf::from("/tmp/x");
+        let staple = std::path::PathBuf::from("/tmp/server.ocsp");
+        let paths = ServerTlsPaths::from_optional(
+            Some(p.clone()),
+            Some(p.clone()),
+            Some(p.clone()),
+            vec![],
+            Some(staple.clone()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(paths.ocsp_staple, Some(staple));
     }
 
     #[tokio::test]

--- a/crates/llmvm-cli/src/main.rs
+++ b/crates/llmvm-cli/src/main.rs
@@ -302,6 +302,21 @@ enum CoordinatorCommand {
         /// trio — passing CRLs without mTLS is a startup error.
         #[arg(long, value_name = "FILE")]
         tls_client_crl: Vec<PathBuf>,
+        /// post1-T-4.3 (0.7.x): DER-encoded OCSP response to
+        /// staple into every TLS handshake. When set, rustls
+        /// includes the pre-fetched response so clients do not
+        /// need a separate OCSP request to check the server
+        /// cert's revocation status.
+        ///
+        /// Generate with:
+        ///   openssl ocsp -issuer issuer.pem -cert server.pem \
+        ///     -url http://ocsp.example.com -respout server.ocsp
+        ///
+        /// File must be DER-encoded (binary). Requires the full
+        /// `--tls-cert/--tls-key/--tls-client-ca` trio — passing
+        /// an OCSP staple without mTLS is a startup error.
+        #[arg(long, value_name = "FILE")]
+        tls_ocsp_staple: Option<PathBuf>,
     },
     /// Drive a submit-only workflow run to terminal status by
     /// computing downstream-ready successors as workers complete
@@ -1354,6 +1369,7 @@ fn run_coordinator(
             tls_key,
             tls_client_ca,
             tls_client_crl,
+            tls_ocsp_staple,
         } => {
             #[cfg(feature = "persist-sqlite")]
             {
@@ -1366,6 +1382,7 @@ fn run_coordinator(
                     tls_key,
                     tls_client_ca,
                     tls_client_crl,
+                    tls_ocsp_staple,
                 )?;
                 coordinator::run_serve(
                     resolved,
@@ -1392,6 +1409,7 @@ fn run_coordinator(
                     tls_key,
                     tls_client_ca,
                     tls_client_crl,
+                    tls_ocsp_staple,
                 );
                 return Err("`coordinator serve` requires the `persist-sqlite` feature".into());
             }

--- a/docs/guides/mtls-crl.md
+++ b/docs/guides/mtls-crl.md
@@ -67,6 +67,39 @@ that was already in force.
 > follow-up; reload semantics above describe the intended
 > behavior.
 
+## OCSP Stapling (post1-T-4.3)
+
+`boruna coordinator serve` also accepts `--tls-ocsp-staple <FILE>` to
+embed a pre-fetched OCSP response in every TLS handshake. This lets
+connecting clients verify that the server certificate is not revoked
+without making a separate round-trip to an OCSP responder.
+
+The file must be **DER-encoded** (binary) — this is the format rustls
+expects internally. Generate it with OpenSSL:
+
+```sh
+openssl ocsp \
+  -issuer issuer.pem \
+  -cert   server.pem \
+  -url    http://ocsp.your-ca.example.com \
+  -respout server.ocsp
+```
+
+Pass it to the coordinator:
+
+```sh
+boruna coordinator serve \
+  --tls-cert         /etc/boruna/tls/server.pem \
+  --tls-key          /etc/boruna/tls/server.key \
+  --tls-client-ca    /etc/boruna/tls/clients-ca.pem \
+  --tls-ocsp-staple  /etc/boruna/tls/server.ocsp
+```
+
+The flag requires the full `--tls-cert/--tls-key/--tls-client-ca`
+trio; passing it on a plaintext server is a fatal startup error.
+Refresh the staple file (OCSP responses typically expire within a few
+hours to days) and restart the process to pick up the new response.
+
 ## Verification recipe (manual)
 
 After deploying, exercise the revocation path with a smoke test:


### PR DESCRIPTION
## Summary

- Adds `--tls-ocsp-staple <FILE>` to `boruna coordinator serve` (0.7.x speculative branch)
- Server loads a DER-encoded OCSP response at startup and staples it into the TLS handshake via rustls's `with_single_cert_with_ocsp()`
- Connecting clients receive server cert revocation proof without making a separate OCSP request

## Depends on

T-4.2 (PR #27, already merged into 0.7.x): CRL revocation support

## Implementation

- `ServerTlsPaths.ocsp_staple: Option<PathBuf>` — optional OCSP response file
- `from_optional()` gains a 5th `ocsp_staple` argument; passing OCSP without the TLS trio is a typed startup error
- `build_server_tls()` loads DER bytes and calls `with_single_cert_with_ocsp(certs, key, ocsp_bytes)` when the staple is set; falls back to `with_single_cert()` otherwise
- Startup error on missing/unreadable OCSP file (fail-fast)

## Test plan

- [ ] `parse_tls_flags_ocsp_without_mtls_rejected` — OCSP file without TLS trio → startup error
- [ ] `parse_tls_flags_ocsp_with_valid_mtls_accepted` — OCSP path with all three TLS flags → `ocsp_staple: Some(path)`
- [ ] All existing `parse_tls_flags_*` tests pass with updated `from_optional` signature
- [ ] `cargo test -p boruna-cli --features serve` — all pass
- [ ] `cargo clippy -p boruna-cli --features serve -- -D warnings` — clean

This change ships on 0.7.x only — not on the 1.x LTS surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)