### PR TITLE
feat(post1-T-4.1): MCP protocol_version 2 — natural JSON value encoding (0.7.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   Requires the full mTLS trio; file is read at startup (fail-fast).
   See `docs/guides/mtls-crl.md` for the generation recipe.
   **0.7.x-only** feature: not part of the 1.x LTS surface.
-
+- **MCP protocol_version 2** (post1-T-4.1, 0.7.x only).
+  `boruna_run` result values now use natural JSON encoding: `Option::None` → `null`,
+  `Option::Some(v)` → `v` (unwrapped), `Result::Ok(v)` → `{"ok": v}`,
+  `Result::Err(v)` → `{"err": v}`. Records serialize as named-field objects
+  (`{"field": value}`) rather than positional arrays. Enum variants use
+  `{"VariantName": payload}` or just `"VariantName"` for unit variants.
+  **Breaking**: integrators built against `protocol_version: 1` must update
+  their parsers. All responses now carry `"protocol_version": 2`.
 - `boruna coordinator serve --tls-client-crl <FILE>` (post1-T-4.2)
   loads PEM-encoded X509 CRLs at startup and feeds them to
   rustls's `WebPkiClientVerifier::with_crls`. Connections from

--- a/crates/boruna-mcp/src/tools/mod.rs
+++ b/crates/boruna-mcp/src/tools/mod.rs
@@ -18,7 +18,7 @@ pub mod workflow;
 /// `docs/reference/mcp-server.md` under "Stability".
 ///
 /// FleetQ ask [#6](https://github.com/escapeboy/boruna/issues/6).
-pub(crate) const TOOL_RESPONSE_PROTOCOL_VERSION: u32 = 1;
+pub(crate) const TOOL_RESPONSE_PROTOCOL_VERSION: u32 = 2;
 
 #[cfg(test)]
 mod protocol_version_tests {
@@ -202,9 +202,9 @@ mod protocol_version_tests {
     // ── meta ──
 
     #[test]
-    fn protocol_version_constant_is_one() {
-        // Locks the wire-format version. Bump only on a breaking shape change
-        // anywhere in the tool envelope. See docs/reference/mcp-server.md.
-        assert_eq!(TOOL_RESPONSE_PROTOCOL_VERSION, 1);
+    fn protocol_version_constant_is_two() {
+        // Locks the wire-format version. Bumped to 2 (post1-T-4.1) for the
+        // natural JSON value encoding change in boruna_run responses.
+        assert_eq!(TOOL_RESPONSE_PROTOCOL_VERSION, 2);
     }
 }

--- a/crates/boruna-mcp/src/tools/run.rs
+++ b/crates/boruna-mcp/src/tools/run.rs
@@ -1,3 +1,4 @@
+use boruna_bytecode::module::{Module, TypeKind};
 use boruna_bytecode::Value;
 use boruna_vm::capability_gateway::{CapabilityGateway, Policy};
 use boruna_vm::error::VmError;
@@ -175,7 +176,7 @@ where
         Ok(value) => {
             // Serialize result and ui_output under the optional output-size cap.
             let max_output_bytes = limits.and_then(|l| l.max_output_bytes);
-            let result_json = match format_value_capped(&value, max_output_bytes) {
+            let result_json = match format_value_capped(&value, max_output_bytes, vm.module()) {
                 Ok(j) => j,
                 Err(over) => return over.to_response(vm.step_count()),
             };
@@ -184,7 +185,7 @@ where
                 .map(|cap| cap.saturating_sub(serialized_size(&result_json) as u64));
             let mut ui_output_json: Vec<serde_json::Value> = Vec::new();
             for tree in &vm.ui_output {
-                let tree_json = match format_value_capped(tree, remaining) {
+                let tree_json = match format_value_capped(tree, remaining, vm.module()) {
                     Ok(j) => j,
                     Err(_) => {
                         // Use the original cap (not the dynamic remaining) as
@@ -388,6 +389,7 @@ impl OutputBudgetExceeded {
 fn format_value_capped(
     value: &Value,
     budget: Option<u64>,
+    module: &Module,
 ) -> Result<serde_json::Value, OutputBudgetExceeded> {
     if let Some(cap) = budget {
         // Cheap pre-check: a single very-large String is the canonical
@@ -399,7 +401,7 @@ fn format_value_capped(
             }
         }
     }
-    let json = format_value(value);
+    let json = format_value_v2(value, module);
     if let Some(cap) = budget {
         if serialized_size(&json) as u64 > cap {
             return Err(OutputBudgetExceeded { cap });
@@ -590,43 +592,64 @@ pub(crate) fn parse_policy(value: Option<&JsonValue>) -> Result<Policy, ParsePol
     }
 }
 
-fn format_value(value: &Value) -> serde_json::Value {
+/// Protocol v2 value serializer. Uses natural JSON shapes for Option, Result,
+/// Record, and Enum instead of the v1 wrapper objects.
+fn format_value_v2(value: &Value, module: &Module) -> serde_json::Value {
     match value {
         Value::Int(n) => serde_json::json!(n),
         Value::Float(f) => serde_json::json!(f),
         Value::String(s) => serde_json::json!(s),
         Value::Bool(b) => serde_json::json!(b),
-        Value::Unit => serde_json::json!(null),
-        Value::None => serde_json::json!({"option": "None"}),
-        Value::Some(v) => serde_json::json!({"option": "Some", "value": format_value(v)}),
-        Value::Ok(v) => serde_json::json!({"result": "Ok", "value": format_value(v)}),
-        Value::Err(v) => serde_json::json!({"result": "Err", "value": format_value(v)}),
+        Value::Unit => serde_json::Value::Null,
+        Value::None => serde_json::Value::Null,
+        Value::Some(v) => format_value_v2(v, module),
+        Value::Ok(v) => serde_json::json!({"ok": format_value_v2(v, module)}),
+        Value::Err(v) => serde_json::json!({"err": format_value_v2(v, module)}),
         Value::List(items) => {
-            serde_json::json!(items.iter().map(format_value).collect::<Vec<_>>())
+            serde_json::json!(items.iter().map(|v| format_value_v2(v, module)).collect::<Vec<_>>())
         }
         Value::Record { type_id, fields } => {
-            serde_json::json!({
-                "type": "record",
-                "type_id": type_id,
-                "fields": fields.iter().map(format_value).collect::<Vec<serde_json::Value>>(),
-            })
+            let idx = *type_id as usize;
+            if let Some(typedef) = module.types.get(idx) {
+                if let TypeKind::Record { fields: field_defs } = &typedef.kind {
+                    let mut obj = serde_json::Map::new();
+                    for (i, field_val) in fields.iter().enumerate() {
+                        let name = field_defs
+                            .get(i)
+                            .map(|(n, _)| n.as_str())
+                            .unwrap_or("_unknown");
+                        obj.insert(name.to_string(), format_value_v2(field_val, module));
+                    }
+                    return serde_json::Value::Object(obj);
+                }
+            }
+            // Fallback: positional array when type table is unavailable.
+            serde_json::json!(fields.iter().map(|v| format_value_v2(v, module)).collect::<Vec<_>>())
         }
         Value::Enum {
             type_id,
             variant,
             payload,
         } => {
-            serde_json::json!({
-                "type": "enum",
-                "type_id": type_id,
-                "variant": variant,
-                "payload": format_value(payload),
-            })
+            let idx = *type_id as usize;
+            if let Some(typedef) = module.types.get(idx) {
+                if let TypeKind::Enum { variants } = &typedef.kind {
+                    if let Some((variant_name, payload_type)) = variants.get(*variant as usize) {
+                        if payload_type.is_none() {
+                            return serde_json::json!(variant_name);
+                        } else {
+                            return serde_json::json!({variant_name: format_value_v2(payload, module)});
+                        }
+                    }
+                }
+            }
+            // Fallback when type table lookup fails.
+            serde_json::json!({"variant": variant, "payload": format_value_v2(payload, module)})
         }
         Value::Map(entries) => {
             let obj: serde_json::Map<String, serde_json::Value> = entries
                 .iter()
-                .map(|(k, v)| (k.clone(), format_value(v)))
+                .map(|(k, v)| (k.clone(), format_value_v2(v, module)))
                 .collect();
             serde_json::Value::Object(obj)
         }

--- a/crates/boruna-mcp/src/tools/run.rs
+++ b/crates/boruna-mcp/src/tools/run.rs
@@ -606,7 +606,10 @@ fn format_value_v2(value: &Value, module: &Module) -> serde_json::Value {
         Value::Ok(v) => serde_json::json!({"ok": format_value_v2(v, module)}),
         Value::Err(v) => serde_json::json!({"err": format_value_v2(v, module)}),
         Value::List(items) => {
-            serde_json::json!(items.iter().map(|v| format_value_v2(v, module)).collect::<Vec<_>>())
+            serde_json::json!(items
+                .iter()
+                .map(|v| format_value_v2(v, module))
+                .collect::<Vec<_>>())
         }
         Value::Record { type_id, fields } => {
             let idx = *type_id as usize;
@@ -624,7 +627,10 @@ fn format_value_v2(value: &Value, module: &Module) -> serde_json::Value {
                 }
             }
             // Fallback: positional array when type table is unavailable.
-            serde_json::json!(fields.iter().map(|v| format_value_v2(v, module)).collect::<Vec<_>>())
+            serde_json::json!(fields
+                .iter()
+                .map(|v| format_value_v2(v, module))
+                .collect::<Vec<_>>())
         }
         Value::Enum {
             type_id,

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -26,7 +26,7 @@ Both `--templates-dir` and `--libs-dir` are optional. Defaults are `templates` a
 The tools below share several conventions:
 
 - **All tools return JSON inside an MCP `Content::text` payload.** Responses are pretty-printed.
-- **Every response — success and failure — carries `protocol_version: 1`.** This is the wire-format version of the response envelope. It bumps **only** on a breaking shape change (field rename, removal, type change, or `error_kind` semantics change). Additive changes keep the version. Integrators should reject any response whose `protocol_version` exceeds the version they were built against, and may safely upgrade their parsers when the field stays the same. See the [Stability section](#stability) for the full versioning policy.
+- **Every response — success and failure — carries `protocol_version: 2`.** This is the wire-format version of the response envelope. It bumps **only** on a breaking shape change (field rename, removal, type change, or `error_kind` semantics change). Additive changes keep the version. Integrators should reject any response whose `protocol_version` exceeds the version they were built against, and may safely upgrade their parsers when the field stays the same. See the [Stability section](#stability) for the full versioning policy.
 - **Domain errors are returned as `success: false` JSON, not as MCP errors.** This includes compile failures, runtime errors, validation errors, parse errors, etc. MCP-protocol errors (returned as `McpError`) are reserved for transport-level problems — most commonly when a `source` argument exceeds the **1 MB limit** enforced by every source-accepting tool.
 - **Source code is passed as a string**, not a file path. Tool callers are responsible for reading files themselves.
 - **Synchronous Boruna APIs run inside `tokio::task::spawn_blocking`.** That means tool calls don't starve the MCP event loop, but each call is single-threaded.
@@ -35,7 +35,7 @@ The tools below share several conventions:
 
 ## Tools
 
-> **Note on the JSON examples below:** for brevity, the per-tool examples show only the body fields. Every actual response — success and failure — also includes `"protocol_version": 1` immediately after `"success"`. See the [Conventions](#conventions) and [Stability](#stability) sections for the full contract.
+> **Note on the JSON examples below:** for brevity, the per-tool examples show only the body fields. Every actual response — success and failure — also includes `"protocol_version": 2` immediately after `"success"`. See the [Conventions](#conventions) and [Stability](#stability) sections for the full contract.
 
 ### `boruna_compile`
 
@@ -170,20 +170,23 @@ Plus the `errors` shape from `boruna_compile` if compilation fails before the ru
 
 `error_kind` values: `runtime_error`, `invalid_policy`. Compile failures are returned without an `error_kind` (they use the `errors` array). Exceeding `max_steps` is reported as `runtime_error` with a step-limit message — there is no distinct kind for it.
 
-**Value encoding** — primitives are passed through directly (`Int` → number, `String` → string, `Bool` → bool, `Unit` → `null`). Tagged values use the shapes:
+**Value encoding (protocol_version 2)** — primitives are passed through directly (`Int` → number, `String` → string, `Bool` → bool, `Unit` → `null`). Tagged values use natural JSON shapes:
 
 ```json
-{"option": "None"}                         // Value::None
-{"option": "Some", "value": <inner>}       // Value::Some
-{"result": "Ok",   "value": <inner>}       // Value::Ok
-{"result": "Err",  "value": <inner>}       // Value::Err
-{"type": "record", "type_id": 4, "fields": [...]}
-{"type": "enum",   "type_id": 6, "variant": "Tag", "payload": <inner>}
+null                                       // Value::None (unwrapped)
+<inner>                                    // Value::Some (unwrapped)
+{"ok":  <inner>}                           // Value::Ok
+{"err": <inner>}                           // Value::Err
+{"field1": v1, "field2": v2}              // Value::Record (named fields from type table)
+{"VariantName": <payload>}                 // Value::Enum with payload
+"VariantName"                              // Value::Enum unit variant
 {"actor_id": 1}                            // Value::ActorId
 {"fn_ref": 12}                             // Value::FnRef
 ```
 
-`Value::List` becomes a JSON array; `Value::Map` becomes a JSON object.
+`Value::List` becomes a JSON array; `Value::Map` becomes a JSON object. When the module type table does not contain the referenced type (e.g. in a stripped module), records fall back to positional arrays and enums fall back to `{"variant": N, "payload": <inner>}`.
+
+> **Breaking change from protocol_version 1:** integrators built against v1 must update their parsers. The v1 shapes (`{"option": "None"}`, `{"option": "Some", "value": ...}`, `{"result": "Ok", "value": ...}`, `{"type": "record", ...}`, `{"type": "enum", ...}`) are no longer emitted.
 
 ---
 
@@ -440,7 +443,7 @@ The `validation` object is present only when `validate: true`. If validation fai
 
 ## Stability
 
-- **`protocol_version: 1`** is the wire-format version of the response envelope, present on every tool response (success and failure). Locked by `crates/boruna-mcp/src/tools/mod.rs::TOOL_RESPONSE_PROTOCOL_VERSION`; a regression test (`protocol_version_tests`) asserts coverage across both success and failure paths of every tool. Bumped only on a breaking shape change anywhere in the envelope; additive changes keep the version.
+- **`protocol_version: 2`** is the wire-format version of the response envelope, present on every tool response (success and failure). Locked by `crates/boruna-mcp/src/tools/mod.rs::TOOL_RESPONSE_PROTOCOL_VERSION`; a regression test (`protocol_version_tests`) asserts coverage across both success and failure paths of every tool. Bumped only on a breaking shape change anywhere in the envelope; additive changes keep the version. Bumped from 1 to 2 in post1-T-4.1 (0.7.x) for the natural JSON value encoding change in `boruna_run` responses.
 - **Tool names** (`boruna_compile`, `boruna_run`, ...) are stable. Renames require a major version bump.
 - **`error_kind` values** are stable strings. New ones may be added; existing ones are not renamed.
 - **Top-level response fields** (`success`, `protocol_version`, named result fields) are stable. New fields are additive.


### PR DESCRIPTION
## Summary

Breaking change for the 0.7.x branch — bumps `TOOL_RESPONSE_PROTOCOL_VERSION` from 1 to 2.

- **`Option::None`** → `null` (was `{"option": "None"}`)
- **`Option::Some(v)`** → `v` unwrapped (was `{"option": "Some", "value": v}`)
- **`Result::Ok(v)`** → `{"ok": v}` (was `{"result": "Ok", "value": v}`)
- **`Result::Err(v)`** → `{"err": v}` (was `{"result": "Err", "value": v}`)
- **Records** → named-field objects `{"field1": v1, "field2": v2}` using the module type table (was positional `{"type":"record","type_id":N,"fields":[...]}`)
- **Enum variants** → `{"VariantName": payload}` for tagged, `"VariantName"` for unit (was `{"type":"enum","type_id":N,"variant":"Name","payload":...}`)

Fallback for missing type info: records fall back to positional arrays; enums fall back to the v1 shape.

## Why 0.7.x only

This is a breaking wire-format change that cannot go on the 1.x LTS master branch. 0.7.x is the designated channel for LTS-incompatible improvements.

## Files

- `crates/boruna-mcp/src/tools/run.rs` — new `format_value_v2(value, module)`, updated `format_value_capped` to accept `&Module`
- `crates/boruna-mcp/src/tools/mod.rs` — version constant 1 → 2, lock test updated
- `docs/reference/mcp-server.md` — updated Stability section + value encoding table
- `CHANGELOG.md` — unreleased entry

## Test plan

- [x] `cargo test --workspace` passes (all crates, locally verified)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)