### PR TITLE
docs(post1-T-3.4): stdlib reference docs for all 11 std-* packages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,24 @@ Task-oriented walkthroughs:
 - [Worker Capability Tagging](./guides/worker-capability-tagging.md) — heterogeneous fleet placement
 - [Migration](./guides/migration.md) — `boruna migrate` for upgrading legacy bundles and workflow files
 
+## Standard Libraries
+
+Reference pages for all 11 built-in `std-*` packages:
+
+- [std-ui](./reference/stdlib/std-ui.md) — declarative UI primitives
+- [std-forms](./reference/stdlib/std-forms.md) — model-driven form engine
+- [std-authz](./reference/stdlib/std-authz.md) — role and permission enforcement
+- [std-http](./reference/stdlib/std-http.md) — typed HTTP effect wrappers
+- [std-db](./reference/stdlib/std-db.md) — typed database query helpers
+- [std-sync](./reference/stdlib/std-sync.md) — offline queue and conflict resolution
+- [std-validation](./reference/stdlib/std-validation.md) — composable validation rules
+- [std-routing](./reference/stdlib/std-routing.md) — declarative routing model
+- [std-storage](./reference/stdlib/std-storage.md) — typed local persistence abstraction
+- [std-notifications](./reference/stdlib/std-notifications.md) — notification queue and toast helpers
+- [std-testing](./reference/stdlib/std-testing.md) — test helpers for framework apps
+
+See [Stdlib Libraries](./STD_LIBRARIES_SPEC.md) for the full spec and [stdlib-graduation-tracker.md](./stdlib-graduation-tracker.md) for graduation status.
+
 ## Reference
 
 Complete API and format documentation:

--- a/docs/reference/stdlib/std-authz.md
+++ b/docs/reference/stdlib/std-authz.md
@@ -1,0 +1,126 @@
+# std-authz
+
+> Role and permission enforcement via policies
+
+**Package:** `std.authz`  **Version:** `0.1.0`  **Capabilities required:** none
+
+## Overview
+
+`std-authz` provides a simple, policy-driven authorization model based on named roles and numeric privilege levels. Call `authz_check` in your `update` handler before applying any state change that requires a permission gate. Because all functions are pure and deterministic, authorization decisions are fully auditable and replayable from the evidence bundle.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.authz": "0.1.0"
+```
+
+## API Reference
+
+### Types
+
+#### `AuthzPolicy`
+
+```
+type AuthzPolicy {
+    admin_role: String,
+    editor_role: String,
+    viewer_role: String,
+    admin_level: Int,
+    editor_level: Int,
+    viewer_level: Int
+}
+```
+
+Maps role names to numeric privilege levels. Higher levels have broader access.
+
+#### `Role`
+
+```
+type Role { name: String, level: Int }
+```
+
+#### `Permission`
+
+```
+type Permission { resource: String, action: String }
+```
+
+#### `RolePermission`
+
+```
+type RolePermission { role_name: String, resource: String, action: String }
+```
+
+#### `AuthzResult`
+
+```
+type AuthzResult { allowed: Int, reason: String }
+```
+
+- `allowed` — `1` if the operation is permitted, `0` if denied
+- `reason` — human-readable explanation for logging
+
+### Functions
+
+##### `authz_default_policy() -> AuthzPolicy`
+
+Returns the built-in three-tier policy: `admin` (level 100), `editor` (level 50), `viewer` (level 10).
+
+##### `authz_check(policy: AuthzPolicy, role_name: String, resource: String, action: String) -> AuthzResult`
+
+The primary authorization gate. Checks whether `role_name` is permitted to perform `action` on `resource`.
+
+Supported actions: `"read"` (requires viewer+), `"write"` (requires editor+), `"delete"` (requires admin).
+
+**Parameters**
+- `policy` — the active `AuthzPolicy`
+- `role_name` — the principal's role string
+- `resource` — the resource being accessed (informational; used for the reason message)
+- `action` — `"read"`, `"write"`, or `"delete"`
+
+**Returns** — `AuthzResult` with `allowed: 1` or `allowed: 0` and a descriptive reason.
+
+**Example**
+```
+fn main() -> Int {
+  let policy: AuthzPolicy = authz_default_policy()
+  let result: AuthzResult = authz_check(policy, "editor", "documents", "write")
+  result.allowed
+}
+```
+
+##### `authz_require_role(policy: AuthzPolicy, role_name: String, min_level: Int) -> AuthzResult`
+
+Returns allowed if the role's numeric level meets or exceeds `min_level`. Useful for custom thresholds beyond the three built-in actions.
+
+##### `authz_role_level(policy: AuthzPolicy, role_name: String) -> Int`
+
+Returns the numeric privilege level for a role name. Returns `0` for unknown roles.
+
+##### `authz_guard_update(policy: AuthzPolicy, role_name: String, resource: String, action: String) -> Int`
+
+Convenience wrapper that calls `authz_check` and returns only the `allowed` integer — handy in `if` guards.
+
+##### `authz_is_admin(policy: AuthzPolicy, role_name: String) -> Int`
+
+Returns `1` if `role_name` matches the policy's admin role.
+
+##### `authz_can_write(policy: AuthzPolicy, role_name: String) -> Int`
+
+Returns `1` if the role has editor-level or higher privileges.
+
+##### `authz_can_read(policy: AuthzPolicy, role_name: String) -> Int`
+
+Returns `1` if the role has viewer-level or higher privileges.
+
+## Capabilities
+
+None. All functions are pure predicates with no side effects.
+
+## Notes / Limitations
+
+- The policy is a fixed three-role structure. Custom roles beyond admin/editor/viewer can be checked via `authz_require_role` with an explicit `min_level`.
+- Role names are compared by string equality; casing matters.
+- `resource` is passed through to the reason string but is not used in access-control logic — access depends solely on the action and role level.

--- a/docs/reference/stdlib/std-db.md
+++ b/docs/reference/stdlib/std-db.md
@@ -1,0 +1,145 @@
+# std-db
+
+> Typed database query helpers
+
+**Package:** `std.db`  **Version:** `0.1.0`  **Capabilities required:** `db.query`
+
+## Overview
+
+`std-db` provides a builder API for constructing typed database queries and converting them to `Effect` values for execution. Build a `Query` with the CRUD helpers, refine it with `db_where`, `db_order`, and `db_paginate`, then call `db_to_effect` to hand it off to the runtime. The library also includes a `Pagination` type and helpers for navigating paged result sets.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.db": "0.1.0"
+```
+
+Your policy must grant `db.query`.
+
+## API Reference
+
+### Types
+
+#### `Effect`
+
+```
+type Effect { kind: String, payload: String, callback_tag: String }
+```
+
+#### `Query`
+
+```
+type Query {
+    operation: String,
+    table: String,
+    columns: String,
+    conditions: String,
+    order_by: String,
+    limit_val: Int,
+    offset_val: Int
+}
+```
+
+A portable query descriptor. `columns` is a comma-separated list; `conditions` is a raw filter expression string.
+
+#### `Pagination`
+
+```
+type Pagination { page: Int, per_page: Int, total: Int, total_pages: Int }
+```
+
+Computed pagination metadata. Use with `pagination_has_next` / `pagination_has_prev` in your view.
+
+### Functions
+
+#### Query builders
+
+##### `db_select(table: String, columns: String) -> Query`
+
+Creates a SELECT query for the specified columns.
+
+**Example**
+```
+fn main() -> Int {
+  let q: Query = db_select("users", "id, name, email")
+  let q2: Query = db_where(q, "active = 1")
+  let q3: Query = db_order(q2, "name")
+  let q4: Query = db_paginate(q3, 1, 20)
+  let eff: Effect = db_to_effect(q4, "users_loaded")
+  0
+}
+```
+
+##### `db_insert(table: String, columns: String, values: String) -> Query`
+
+Creates an INSERT query. `columns` and `values` are comma-separated strings corresponding to each other positionally.
+
+##### `db_update(table: String, sets: String, conditions: String) -> Query`
+
+Creates an UPDATE query. `sets` is a comma-separated list of `column = value` assignments.
+
+##### `db_delete(table: String, conditions: String) -> Query`
+
+Creates a DELETE query filtered by `conditions`.
+
+#### Query modifiers
+
+##### `db_where(query: Query, condition: String) -> Query`
+
+Replaces the query's condition expression. Call after the initial builder.
+
+##### `db_order(query: Query, column: String) -> Query`
+
+Sets the ORDER BY column.
+
+##### `db_limit(query: Query, limit_val: Int) -> Query`
+
+Sets a row limit.
+
+##### `db_offset(query: Query, offset_val: Int) -> Query`
+
+Sets a row offset.
+
+##### `db_paginate(query: Query, page: Int, per_page: Int) -> Query`
+
+Sets `limit_val` and `offset_val` from a 1-based page number and page size. Equivalent to calling `db_limit` and `db_offset` with the computed values.
+
+#### Effect dispatch
+
+##### `db_to_effect(query: Query, callback_tag: String) -> Effect`
+
+Converts a `Query` to an `Effect` with `kind: "db_query"`. Return this from `update` to execute the query.
+
+#### Pagination helpers
+
+##### `pagination_info(page: Int, per_page: Int, total: Int) -> Pagination`
+
+Computes the `Pagination` record from a known total row count.
+
+##### `pagination_has_next(p: Pagination) -> Int`
+
+Returns `1` if there is a next page.
+
+##### `pagination_has_prev(p: Pagination) -> Int`
+
+Returns `1` if there is a previous page.
+
+##### `pagination_next_page(p: Pagination) -> Int`
+
+Returns the next page number, or the current page if already at the last.
+
+##### `pagination_prev_page(p: Pagination) -> Int`
+
+Returns the previous page number, or `1` if already at the first.
+
+## Capabilities
+
+Requires `db.query`. Queries are executed by the runtime's capability handler; the library itself produces only data structures.
+
+## Notes / Limitations
+
+- Condition strings (`conditions`, `sets`) are passed through verbatim to the runtime. The library does not perform sanitization; callers are responsible for safe parameterization.
+- `db_paginate` uses 1-based page numbers. Page `0` or negative values produce a negative offset.
+- `total_pages` is computed as `ceil(total / per_page)`; when `total == 0` the result is `1`.

--- a/docs/reference/stdlib/std-forms.md
+++ b/docs/reference/stdlib/std-forms.md
@@ -1,0 +1,141 @@
+# std-forms
+
+> Model-driven form engine with validation and state tracking
+
+**Package:** `std.forms`  **Version:** `0.1.0`  **Capabilities required:** none
+
+## Overview
+
+`std-forms` manages the lifecycle of multi-field forms inside framework apps. It provides two complementary state types — `FieldState` for individual inputs and `FormState` for the whole form — and a set of pure functions to transition between them. Use it in your `update(State, Msg) -> UpdateResult` handler to track dirty/touched flags, field errors, and submission state without writing that boilerplate yourself.
+
+`std-forms` depends on `std.validation` for composable rule checking.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.forms": "0.1.0"
+```
+
+`std.validation` is pulled in automatically as a transitive dependency.
+
+## API Reference
+
+### Types
+
+#### `FieldState`
+
+```
+type FieldState { name: String, value: String, touched: Int, dirty: Int, error: String }
+```
+
+- `touched` — `1` if the user has focused the field at least once
+- `dirty` — `1` if the value has changed from its initial state
+- `error` — current validation error message, or `""` when valid
+
+#### `FormState`
+
+```
+type FormState {
+    field_count: Int,
+    submitted: Int,
+    valid: Int,
+    current_field: String,
+    current_value: String,
+    current_error: String
+}
+```
+
+- `submitted` — `1` after a successful `form_submit`
+- `valid` — `0` as soon as any field error is set; reset by `form_clear_errors`
+
+### Functions
+
+#### Form lifecycle
+
+##### `form_init(field_count: Int) -> FormState`
+
+Creates a fresh form. Pass the number of fields to pre-declare capacity.
+
+##### `form_set_field(form: FormState, name: String, value: String) -> FormState`
+
+Records the most-recently changed field name and value. Call this on every input change message.
+
+##### `form_set_error(form: FormState, field: String, error: String) -> FormState`
+
+Attaches a validation error to a named field and marks the form invalid.
+
+##### `form_clear_errors(form: FormState) -> FormState`
+
+Clears all errors and resets `valid` to `1`.
+
+##### `form_submit(form: FormState) -> FormState`
+
+Transitions the form to the submitted state if `valid == 1`. No-ops if the form is invalid.
+
+##### `form_reset(form: FormState) -> FormState`
+
+Resets all fields to their initial state while preserving `field_count`.
+
+#### Form predicates
+
+##### `form_is_valid(form: FormState) -> Int`
+
+Returns `1` if no errors are set.
+
+##### `form_is_submitted(form: FormState) -> Int`
+
+Returns `1` after a successful submission.
+
+#### Field lifecycle
+
+##### `field_init(name: String) -> FieldState`
+
+Creates a fresh field with an empty value and no errors.
+
+##### `field_set_value(field: FieldState, value: String) -> FieldState`
+
+Updates the field value and marks it dirty.
+
+##### `field_touch(field: FieldState) -> FieldState`
+
+Marks the field as touched (user has interacted with it).
+
+##### `field_set_error(field: FieldState, error: String) -> FieldState`
+
+Attaches a validation error message.
+
+##### `field_clear_error(field: FieldState) -> FieldState`
+
+Clears any error message.
+
+##### `field_is_valid(field: FieldState) -> Int`
+
+Returns `1` if the field has no error.
+
+##### `field_reset(field: FieldState) -> FieldState`
+
+Resets to empty, untouched, and error-free while keeping the field name.
+
+**Example**
+```
+fn main() -> Int {
+  let form: FormState = form_init(2)
+  let name_field: FieldState = field_init("name")
+  let name_typed: FieldState = field_set_value(name_field, "Alice")
+  let name_visited: FieldState = field_touch(name_typed)
+  let form2: FormState = form_set_field(form, "name", "Alice")
+  let result: FormState = form_submit(form2)
+  result.submitted
+}
+```
+
+## Capabilities
+
+None. All state transitions are pure functions.
+
+## Notes / Limitations
+
+- `FormState` stores only the most-recently changed field. Apps with multiple fields should maintain per-field `FieldState` values in their own `State` record and use `FormState` for overall validity and submission tracking.
+- `field_count` is informational only; the engine does not iterate over fields.

--- a/docs/reference/stdlib/std-http.md
+++ b/docs/reference/stdlib/std-http.md
@@ -1,0 +1,129 @@
+# std-http
+
+> Safe typed HTTP effect wrappers
+
+**Package:** `std.http`  **Version:** `0.1.0`  **Capabilities required:** `net.fetch`
+
+## Overview
+
+`std-http` wraps outbound HTTP calls as typed `Effect` values. Your `update` handler returns these effects; the Boruna runtime dispatches them through the `net.fetch` capability and delivers responses back via the named `callback_tag`. This keeps network I/O out of pure logic and makes every request auditable in the evidence bundle. The library also provides retry configuration helpers and status-code predicates.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.http": "0.1.0"
+```
+
+Your workflow or app policy must grant `net.fetch` to the step that uses this library.
+
+## API Reference
+
+### Types
+
+#### `Effect`
+
+```
+type Effect { kind: String, payload: String, callback_tag: String }
+```
+
+Returned by all request-building functions. Pass it back from `update` to trigger the HTTP call.
+
+#### `HttpRequest`
+
+```
+type HttpRequest { method: String, url: String, body: String, content_type: String }
+```
+
+A fully described request for use with `http_request`.
+
+#### `HttpResponse`
+
+```
+type HttpResponse { status: Int, body: String }
+```
+
+Shape of the response delivered to the `callback_tag` handler.
+
+#### `RetryConfig`
+
+```
+type RetryConfig { max_retries: Int, backoff_ms: Int, multiplier: Int }
+```
+
+Exponential backoff parameters used with `http_next_backoff`.
+
+### Functions
+
+#### Request builders
+
+##### `http_get(url: String, callback_tag: String) -> Effect`
+
+Produces a GET request effect.
+
+**Example**
+```
+fn main() -> Int {
+  let eff: Effect = http_get("https://api.example.com/items", "items_loaded")
+  0
+}
+```
+
+##### `http_post(url: String, body: String, callback_tag: String) -> Effect`
+
+Produces a POST request effect with the given body.
+
+##### `http_put(url: String, body: String, callback_tag: String) -> Effect`
+
+Produces a PUT request effect.
+
+##### `http_delete(url: String, callback_tag: String) -> Effect`
+
+Produces a DELETE request effect.
+
+##### `http_request(req: HttpRequest, callback_tag: String) -> Effect`
+
+Produces an effect from a fully specified `HttpRequest` — use when you need to set `content_type` or other fields explicitly.
+
+#### Retry helpers
+
+##### `http_default_retry() -> RetryConfig`
+
+Returns a sensible default: 3 retries, 1000 ms base backoff, multiplier 2.
+
+##### `http_retry_config(max_retries: Int, backoff_ms: Int, multiplier: Int) -> RetryConfig`
+
+Constructs a custom retry configuration.
+
+##### `http_next_backoff(config: RetryConfig, attempt: Int) -> Int`
+
+Returns the wait duration in milliseconds before the next retry for a given `attempt` index (0-based). Uses fixed exponential steps up to `attempt == 2`; subsequent attempts cap at `backoff_ms * multiplier^2`.
+
+#### Status-code predicates
+
+##### `http_is_success(status: Int) -> Int`
+
+Returns `1` for 2xx status codes.
+
+##### `http_is_error(status: Int) -> Int`
+
+Returns `1` for 4xx and 5xx status codes.
+
+##### `http_should_retry(status: Int) -> Int`
+
+Returns `1` for status `429` (Too Many Requests) or any 5xx — the conditions under which retrying is appropriate.
+
+##### `http_parse_status(payload: String) -> Int`
+
+Parses a status code string to `Int`. Returns `0` if parsing fails.
+
+## Capabilities
+
+Requires `net.fetch`. The VM's `CapabilityGateway` enforces this at runtime; the call is rejected if the active policy does not include `net.fetch`.
+
+## Notes / Limitations
+
+- All functions produce `Effect` values — they do not perform any I/O themselves. Actual network calls happen in the runtime after the `update` function returns.
+- `http_next_backoff` implements three-step exponential backoff only. If `attempt >= 3` the backoff is not further increased in the current implementation.
+- `http_parse_status` is a stub that returns `0`; the runtime is expected to set the status field directly on the response record delivered to the callback.

--- a/docs/reference/stdlib/std-notifications.md
+++ b/docs/reference/stdlib/std-notifications.md
@@ -1,0 +1,133 @@
+# std-notifications
+
+> Notification queue and toast helpers
+
+**Package:** `std.notifications`  **Version:** `0.1.0`  **Capabilities required:** `time.now`
+
+## Overview
+
+`std-notifications` manages a bounded in-memory queue of toast-style notifications. Add messages with the level-specific helpers (`notification_success`, `notification_error`, etc.), dismiss them by ID, and schedule auto-dismiss timers with `notification_dismiss_effect`. All queue management is pure; only auto-dismiss produces a timer `Effect`.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.notifications": "0.1.0"
+```
+
+Your policy must grant `time.now` if you use `notification_dismiss_effect`.
+
+## API Reference
+
+### Types
+
+#### `Effect`
+
+```
+type Effect { kind: String, payload: String, callback_tag: String }
+```
+
+#### `Notification`
+
+```
+type Notification { id: Int, level: String, message: String, dismiss_ms: Int }
+```
+
+- `id` — unique monotonic integer assigned at push time
+- `level` — `"info"`, `"success"`, `"warning"`, or `"error"`
+- `dismiss_ms` — milliseconds until auto-dismiss; `0` means no auto-dismiss
+
+#### `NotificationQueue`
+
+```
+type NotificationQueue {
+    next_id: Int,
+    count: Int,
+    max_visible: Int,
+    last_level: String,
+    last_message: String,
+    last_id: Int
+}
+```
+
+- `next_id` — the ID that will be assigned to the next pushed notification
+- `count` — number of currently visible notifications
+- `max_visible` — cap beyond which new pushes should be blocked or the oldest dropped
+- `last_level` / `last_message` / `last_id` — fields of the most recently pushed notification
+
+### Functions
+
+#### Initialization
+
+##### `notification_init(max_visible: Int) -> NotificationQueue`
+
+Creates an empty queue with the given visible-notification cap.
+
+#### Pushing notifications
+
+##### `notification_info(queue: NotificationQueue, level: String, message: String) -> NotificationQueue`
+
+Pushes a notification with level `"info"` and `dismiss_ms: 3000`.
+
+##### `notification_success(queue: NotificationQueue, message: String) -> NotificationQueue`
+
+Pushes a success notification with `dismiss_ms: 3000`.
+
+##### `notification_warning(queue: NotificationQueue, message: String) -> NotificationQueue`
+
+Pushes a warning notification with `dismiss_ms: 5000`.
+
+##### `notification_error(queue: NotificationQueue, message: String) -> NotificationQueue`
+
+Pushes an error notification with `dismiss_ms: 0` (sticky — does not auto-dismiss).
+
+##### `notification_push(queue: NotificationQueue, level: String, message: String, dismiss_ms: Int) -> NotificationQueue`
+
+Low-level push with explicit level and dismiss duration.
+
+**Example**
+```
+fn main() -> Int {
+  let q: NotificationQueue = notification_init(5)
+  let q1: NotificationQueue = notification_success(q, "Changes saved")
+  let q2: NotificationQueue = notification_error(q1, "Upload failed")
+  q2.count
+}
+```
+
+#### Constructing a notification record
+
+##### `notification_make(id: Int, level: String, message: String, dismiss_ms: Int) -> Notification`
+
+Constructs a `Notification` value directly. Use when rendering the queue in your `view`.
+
+#### Dismissing
+
+##### `notification_dismiss(queue: NotificationQueue, id: Int) -> NotificationQueue`
+
+Decrements `count` by one. The `id` parameter is informational; the implementation does not track individual items in the current version.
+
+##### `notification_dismiss_effect(id: Int, delay_ms: Int) -> Effect`
+
+Produces a timer effect that fires after `delay_ms` milliseconds. Wire the `"notification_dismissed"` callback to call `notification_dismiss` in your `update` handler.
+
+#### Predicates
+
+##### `notification_count(queue: NotificationQueue) -> Int`
+
+Returns the current number of visible notifications.
+
+##### `notification_is_full(queue: NotificationQueue) -> Int`
+
+Returns `1` if `count >= max_visible`.
+
+## Capabilities
+
+`time.now` is required for the timer effect produced by `notification_dismiss_effect`. Queue-management functions are pure and need no capability.
+
+## Notes / Limitations
+
+- The queue does not store individual `Notification` records internally. `last_id`, `last_level`, and `last_message` reflect only the most recently pushed item. To render all visible notifications your app state should maintain a list of `Notification` values alongside the `NotificationQueue`.
+- `notification_dismiss` decrements the count without validating the `id`. Calling it more times than there are visible notifications will clamp at `0`.
+- Auto-dismiss (`dismiss_ms > 0`) requires your `update` handler to return the timer effect and handle the `"notification_dismissed"` callback.

--- a/docs/reference/stdlib/std-routing.md
+++ b/docs/reference/stdlib/std-routing.md
@@ -1,0 +1,96 @@
+# std-routing
+
+> Declarative routing model
+
+**Package:** `std.routing`  **Version:** `0.1.0`  **Capabilities required:** none
+
+## Overview
+
+`std-routing` gives framework apps a lightweight, deterministic routing layer. Routes are declared as `Route` records, and matching is done with pure functions — no parsing magic, no global history object. Define your routes once, call `route_match_first` in your `update` handler when the path changes, and use `route_is_active` in your `view` to highlight the current link.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.routing": "0.1.0"
+```
+
+## API Reference
+
+### Types
+
+#### `Route`
+
+```
+type Route { name: String, path: String, param_count: Int }
+```
+
+- `name` — a stable identifier used throughout the app (e.g. `"home"`, `"users"`)
+- `path` — the URL path string to match against (e.g. `"/"`, `"/users"`)
+- `param_count` — number of dynamic parameters in the path (0 for static routes)
+
+#### `RouteMatch`
+
+```
+type RouteMatch { matched: Int, route_name: String, param1: String, param2: String }
+```
+
+- `matched` — `1` if a route matched, `0` otherwise
+- `route_name` — the name of the matched route, `""` on no match
+- `param1` / `param2` — extracted path parameters (up to two)
+
+### Functions
+
+##### `route_define(name: String, path: String) -> Route`
+
+Declares a static route with no dynamic parameters.
+
+**Example**
+```
+fn main() -> Int {
+  let home: Route = route_define("home", "/")
+  let users: Route = route_define("users", "/users")
+  let settings: Route = route_define("settings", "/settings")
+  let m: RouteMatch = route_match_first(home, users, settings, "/users")
+  m.matched
+}
+```
+
+##### `route_define_with_param(name: String, path: String, param_count: Int) -> Route`
+
+Declares a route that expects `param_count` dynamic path segments.
+
+##### `route_match_path(route: Route, path: String) -> RouteMatch`
+
+Checks a single route against `path`. Returns a no-match result if `route.path != path`.
+
+##### `route_match_first(r1: Route, r2: Route, r3: Route, path: String) -> RouteMatch`
+
+Tries `r1`, `r2`, and `r3` in order and returns the first match. Returns the result of `r3` (which may be a no-match) if none of the first two matched. Use as a three-entry router table.
+
+##### `route_no_match() -> RouteMatch`
+
+Returns a zero-value no-match result. Use as a fallback or default.
+
+##### `route_navigate(route_name: String) -> String`
+
+Returns the route name as a navigation token. The framework dispatches this to the runtime to push the new path.
+
+##### `route_navigate_with_param(route_name: String, param: String) -> String`
+
+Like `route_navigate` but carries a single parameter.
+
+##### `route_is_active(current_route: String, route_name: String) -> Int`
+
+Returns `1` if `current_route == route_name`. Use in `view` to highlight active navigation links.
+
+## Capabilities
+
+None. All functions are pure.
+
+## Notes / Limitations
+
+- `route_match_path` uses exact string equality. Dynamic path segments (e.g. `/users/42`) require the calling app to extract parameters before matching, or use `param_count` as a hint to implement custom segment splitting.
+- `route_match_first` handles exactly three routes. For larger route tables, nest calls or use a series of `route_match_path` checks in your `update` handler.
+- `route_navigate` returns the route name string as a navigation token; the actual URL push is performed by the runtime, not the library.

--- a/docs/reference/stdlib/std-storage.md
+++ b/docs/reference/stdlib/std-storage.md
@@ -1,0 +1,112 @@
+# std-storage
+
+> Typed local persistence abstraction
+
+**Package:** `std.storage`  **Version:** `0.1.0`  **Capabilities required:** `fs.read`, `fs.write`
+
+## Overview
+
+`std-storage` provides a namespaced key-value persistence layer as `Effect` values. Operations are described purely at the `.ax` level; actual I/O happens in the Boruna runtime. Entries carry a monotonic `version` counter which makes conflict detection straightforward and keeps all storage operations fully replay-compatible.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.storage": "0.1.0"
+```
+
+Your policy must grant both `fs.read` and `fs.write`.
+
+## API Reference
+
+### Types
+
+#### `Effect`
+
+```
+type Effect { kind: String, payload: String, callback_tag: String }
+```
+
+#### `StorageKey`
+
+```
+type StorageKey { namespace: String, key: String }
+```
+
+A typed composite key. The namespace scopes keys to a logical bucket (e.g. `"app"`, `"cache"`).
+
+#### `StorageEntry`
+
+```
+type StorageEntry { namespace: String, key: String, value: String, version: Int }
+```
+
+A versioned key-value record. `value` is stored as a JSON string by convention. `version` is a monotonic integer incremented by `storage_bump_version`.
+
+### Functions
+
+#### Key construction
+
+##### `storage_key(namespace: String, key: String) -> StorageKey`
+
+Constructs a typed key. Useful for passing keys around without losing the namespace.
+
+#### Effect builders
+
+##### `storage_get(namespace: String, key: String, callback_tag: String) -> Effect`
+
+Produces a read effect. The runtime delivers the stored value to `callback_tag`.
+
+**Example**
+```
+fn main() -> Int {
+  let eff: Effect = storage_get("app", "settings", "settings_loaded")
+  0
+}
+```
+
+##### `storage_set(namespace: String, key: String, value: String, callback_tag: String) -> Effect`
+
+Produces a write effect. `value` is written at the given key.
+
+##### `storage_delete(namespace: String, key: String, callback_tag: String) -> Effect`
+
+Produces a delete effect. The key is removed from the namespace.
+
+##### `storage_list(namespace: String, callback_tag: String) -> Effect`
+
+Produces a list effect. The runtime delivers all keys in the namespace to `callback_tag`.
+
+#### Entry helpers
+
+##### `storage_make_entry(namespace: String, key: String, value: String, version: Int) -> StorageEntry`
+
+Constructs a `StorageEntry` with an explicit version. Use when deserializing a stored entry.
+
+##### `storage_bump_version(entry: StorageEntry, new_value: String) -> StorageEntry`
+
+Returns a new entry with `value` updated and `version` incremented by one.
+
+**Example: optimistic update**
+```
+fn main() -> Int {
+  let entry: StorageEntry = storage_make_entry("app", "counter", "0", 1)
+  let updated: StorageEntry = storage_bump_version(entry, "1")
+  updated.version
+}
+```
+
+##### `storage_is_newer(a: StorageEntry, b: StorageEntry) -> Int`
+
+Returns `1` if `a.version > b.version`. Use for last-write-wins conflict resolution.
+
+## Capabilities
+
+Requires `fs.read` for read/list operations and `fs.write` for write/delete operations. The capabilities are enforced separately — a step that only reads can be granted `fs.read` alone.
+
+## Notes / Limitations
+
+- `value` is an untyped `String`. By convention store JSON, but the library does not enforce any encoding.
+- Versioning is local only; it does not synchronize with remote storage. For distributed conflict resolution use `std-sync`.
+- All four effect kinds (`storage_read`, `storage_write`, `storage_delete`, `storage_list`) are replay-safe: the runtime records the result in the `EventLog` and replays it deterministically.

--- a/docs/reference/stdlib/std-sync.md
+++ b/docs/reference/stdlib/std-sync.md
@@ -1,0 +1,126 @@
+# std-sync
+
+> Offline queue and conflict resolution helpers
+
+**Package:** `std.sync`  **Version:** `0.1.0`  **Capabilities required:** `net.fetch`
+
+## Overview
+
+`std-sync` tracks local-vs-remote divergence and manages an offline edit queue inside framework apps. All conflict-resolution logic is pure; only `sync_effect` produces a network `Effect`. Use it to build apps that continue working offline and flush pending changes when connectivity is restored.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.sync": "0.1.0"
+```
+
+Your policy must grant `net.fetch` for `sync_effect` calls to succeed.
+
+## API Reference
+
+### Types
+
+#### `Effect`
+
+```
+type Effect { kind: String, payload: String, callback_tag: String }
+```
+
+#### `SyncState`
+
+```
+type SyncState {
+    online: Int,
+    pending_count: Int,
+    synced_count: Int,
+    status: String,
+    local_version: Int,
+    remote_version: Int,
+    conflicts: Int,
+    resolved: Int
+}
+```
+
+- `online` — `1` when connected, `0` when offline
+- `pending_count` — number of local edits not yet synced
+- `synced_count` — cumulative count of successfully synced operations
+- `status` — one of `"idle"`, `"queued"`, `"syncing"`, `"synced"`, `"offline"`, `"conflict"`, `"resolving"`
+- `local_version` / `remote_version` — monotonic counters; divergence indicates pending changes
+- `conflicts` / `resolved` — total conflicts detected vs resolved
+
+### Functions
+
+#### Initialization
+
+##### `sync_init() -> SyncState`
+
+Returns a fresh sync state: online, no pending edits, version `0`.
+
+#### State transitions
+
+##### `sync_queue_edit(state: SyncState) -> SyncState`
+
+Records one new local edit. Increments `pending_count` and `local_version`. Sets status to `"syncing"` if online, `"queued"` if offline.
+
+##### `sync_mark_synced(state: SyncState) -> SyncState`
+
+Acknowledges one successfully synced edit. Decrements `pending_count` and advances `remote_version` to match `local_version`. Status becomes `"synced"` when the queue is drained.
+
+##### `sync_go_offline(state: SyncState) -> SyncState`
+
+Marks the state as offline and sets status to `"offline"`.
+
+##### `sync_go_online(state: SyncState) -> SyncState`
+
+Marks the state as online. Status becomes `"syncing"` if there are pending edits, `"synced"` otherwise.
+
+##### `sync_detect_conflict(state: SyncState) -> SyncState`
+
+Increments the conflict counter and sets status to `"conflict"`. Call when the server rejects an edit due to a version mismatch.
+
+##### `sync_resolve_conflict(state: SyncState, strategy: String) -> SyncState`
+
+Increments `resolved`, bumps `local_version`, and sets status to `"resolving"`. `strategy` is passed for audit purposes; conflict resolution logic is app-specific.
+
+#### Predicates
+
+##### `sync_needs_push(state: SyncState) -> Int`
+
+Returns `1` if there are pending edits and the device is online — the signal to fire a sync effect.
+
+##### `sync_is_idle(state: SyncState) -> Int`
+
+Returns `1` if status is `"idle"` or `"synced"`.
+
+##### `sync_has_conflicts(state: SyncState) -> Int`
+
+Returns `1` if any unresolved conflicts remain.
+
+#### Effects
+
+##### `sync_effect(endpoint: String, callback_tag: String) -> Effect`
+
+Produces an HTTP request effect targeting `endpoint`. Return this from `update` when `sync_needs_push` is true.
+
+**Example**
+```
+fn main() -> Int {
+  let s0: SyncState = sync_init()
+  let s1: SyncState = sync_queue_edit(s0)
+  let s2: SyncState = sync_go_offline(s1)
+  let s3: SyncState = sync_queue_edit(s2)
+  let s4: SyncState = sync_go_online(s3)
+  s4.pending_count
+}
+```
+
+## Capabilities
+
+Requires `net.fetch` for `sync_effect`. All state-transition functions are pure and require no capability.
+
+## Notes / Limitations
+
+- `sync_resolve_conflict` records a resolution but does not merge data. The calling app is responsible for choosing and applying the correct value before calling this function.
+- `sync_needs_push` checks connectivity and pending count only; rate-limiting and retry backoff are not built in. Combine with `std-http`'s `RetryConfig` for production use.

--- a/docs/reference/stdlib/std-testing.md
+++ b/docs/reference/stdlib/std-testing.md
@@ -1,0 +1,116 @@
+# std-testing
+
+> High-level test helpers for framework apps
+
+**Package:** `std.testing`  **Version:** `0.1.0`  **Capabilities required:** none
+
+## Overview
+
+`std-testing` provides assertion functions and aggregation helpers for writing deterministic unit tests directly in `.ax`. Use it inside `fn main()` test programs or alongside the `boruna framework test` command to verify app behavior. Because everything is pure, test programs are fully deterministic and replay-safe.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.testing": "0.1.0"
+```
+
+## API Reference
+
+### Types
+
+#### `TestResult`
+
+```
+type TestResult { passed: Int, label: String, detail: String }
+```
+
+- `passed` — `1` if the assertion succeeded, `0` if it failed
+- `label` — the name of this test case
+- `detail` — `"ok"` on success, or a short failure reason
+
+#### `TestSummary`
+
+```
+type TestSummary { total: Int, passed: Int, failed: Int }
+```
+
+Aggregate result for a group of tests.
+
+### Functions
+
+#### Assertions
+
+##### `assert_eq_int(actual: Int, expected: Int, label: String) -> TestResult`
+
+Passes if `actual == expected`.
+
+**Example**
+```
+fn main() -> Int {
+  let r: TestResult = assert_eq_int(2 + 2, 4, "addition")
+  r.passed
+}
+```
+
+##### `assert_eq_string(actual: String, expected: String, label: String) -> TestResult`
+
+Passes if `actual == expected`.
+
+##### `assert_true(value: Int, label: String) -> TestResult`
+
+Passes if `value == 1`.
+
+##### `assert_false(value: Int, label: String) -> TestResult`
+
+Passes if `value == 0`.
+
+##### `assert_gt(actual: Int, threshold: Int, label: String) -> TestResult`
+
+Passes if `actual > threshold`.
+
+##### `assert_lt(actual: Int, threshold: Int, label: String) -> TestResult`
+
+Passes if `actual < threshold`.
+
+##### `assert_not_empty(value: String, label: String) -> TestResult`
+
+Passes if `value != ""`.
+
+#### Aggregation
+
+##### `test_summary(t1: TestResult, t2: TestResult, t3: TestResult) -> TestSummary`
+
+Computes a summary across exactly three test results.
+
+##### `test_all_passed_2(t1: TestResult, t2: TestResult) -> Int`
+
+Returns `1` if both results passed.
+
+##### `test_all_passed_3(t1: TestResult, t2: TestResult, t3: TestResult) -> Int`
+
+Returns `1` if all three results passed.
+
+**Example: full test program**
+```
+fn main() -> Int {
+  let r1: TestResult = assert_eq_int(1 + 1, 2, "basic addition")
+  let r2: TestResult = assert_true(1, "literal true")
+  let r3: TestResult = assert_not_empty("hello", "non-empty string")
+  let summary: TestSummary = test_summary(r1, r2, r3)
+  summary.failed
+}
+```
+
+A `main` that returns `0` indicates all tests passed (zero failures).
+
+## Capabilities
+
+None. All functions are pure.
+
+## Notes / Limitations
+
+- `test_summary` handles exactly three tests. To summarize more, compute intermediate summaries or use `test_all_passed_2` / `test_all_passed_3` in a chain.
+- There is no test runner built into the library itself. Run test programs with `boruna run <file>.ax` or `boruna framework test` for framework apps.
+- Failure detail is limited to `"mismatch"`, `"expected true"`, `"expected false"`, `"not greater than"`, `"not less than"`, or `"was empty"`. Custom detail messages are not yet supported; use `label` to identify the assertion.

--- a/docs/reference/stdlib/std-ui.md
+++ b/docs/reference/stdlib/std-ui.md
@@ -1,0 +1,136 @@
+# std-ui
+
+> Declarative UI primitives for framework apps
+
+**Package:** `std.ui`  **Version:** `0.1.0`  **Capabilities required:** none
+
+## Overview
+
+`std-ui` provides a small set of pure functions that return `UINode` values — the building blocks of a Boruna framework app's view layer. Every function is deterministic and side-effect-free. Wire these together in your `view(State) -> UINode` implementation to compose layouts, controls, and data-display elements.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.ui": "0.1.0"
+```
+
+## API Reference
+
+### Types
+
+#### `UINode`
+
+```
+type UINode { tag: String, text: String }
+```
+
+The universal tree node returned by every `std-ui` function. The `tag` identifies the element kind; `text` carries the primary display string. The framework runtime interprets these fields when rendering.
+
+### Functions
+
+#### Layout
+
+##### `row(child1: UINode, child2: UINode) -> UINode`
+
+Places two nodes side-by-side in a horizontal row.
+
+##### `column(child1: UINode, child2: UINode) -> UINode`
+
+Stacks two nodes vertically.
+
+##### `stack(child1: UINode, child2: UINode) -> UINode`
+
+Overlays two nodes in a Z-stack (front-to-back).
+
+#### Containers
+
+##### `container(content: UINode) -> UINode`
+
+Wraps a node in a generic container — useful for spacing or styling boundaries.
+
+##### `card(title: String, content: UINode) -> UINode`
+
+Renders a titled card surface around `content`.
+
+**Parameters**
+- `title` — display title shown at the top of the card
+- `content` — the inner `UINode` to render inside
+
+##### `section(heading: String, content: UINode) -> UINode`
+
+A named section with a visible heading above `content`.
+
+#### Controls
+
+##### `button(label: String, on_click: String) -> UINode`
+
+An interactive button.
+
+**Parameters**
+- `label` — text displayed on the button
+- `on_click` — message tag dispatched when clicked
+
+**Example**
+```
+fn main() -> Int {
+  let btn: UINode = button("Save", "save_clicked")
+  0
+}
+```
+
+##### `input(name: String, value: String, on_change: String) -> UINode`
+
+A text input field.
+
+**Parameters**
+- `name` — field identifier
+- `value` — current value to display
+- `on_change` — message tag dispatched on every change
+
+##### `select_field(name: String, selected: String, on_change: String) -> UINode`
+
+A dropdown select field.
+
+##### `checkbox(name: String, checked: Int, on_change: String) -> UINode`
+
+A checkbox. `checked: 1` renders the box checked; `0` renders it unchecked.
+
+#### Data display
+
+##### `table_view(headers: String, row_count: Int) -> UINode`
+
+A tabular view. `headers` is a comma-separated list of column names. `row_count` indicates how many rows the runtime should render.
+
+##### `error_display(message: String) -> UINode`
+
+Shows an error message in a styled error block.
+
+##### `text(content: String) -> UINode`
+
+Renders a plain text node.
+
+##### `badge(label: String, variant: String) -> UINode`
+
+A small inline badge. `variant` hints at the visual style (e.g. `"success"`, `"warning"`, `"error"`).
+
+#### Helpers
+
+##### `empty_node() -> UINode`
+
+A no-op placeholder node that renders nothing. Use when a conditional branch needs to return a `UINode` without visible output.
+
+##### `divider() -> UINode`
+
+A horizontal rule / visual separator.
+
+## Capabilities
+
+None. All functions are pure and return data structures only — no I/O occurs during view construction.
+
+## Notes / Limitations
+
+- `UINode` currently carries only `tag` and `text`. Attributes such as CSS classes, event payloads, and children beyond the first two are not yet representable in the type. This is a v0.x constraint; the type will be expanded in a future release.
+- `row`, `column`, and `stack` each accept exactly two children. Composing more requires nesting calls.
+- `string_length` and other built-ins used internally are resolved by the Boruna runtime.

--- a/docs/reference/stdlib/std-validation.md
+++ b/docs/reference/stdlib/std-validation.md
@@ -1,0 +1,118 @@
+# std-validation
+
+> Reusable composable validation rules
+
+**Package:** `std.validation`  **Version:** `0.1.0`  **Capabilities required:** none
+
+## Overview
+
+`std-validation` provides a small set of pure, composable validation functions. Each returns a `ValidationResult` that carries a pass/fail flag and an error message. Chain results with `validation_merge` to apply multiple rules in sequence and surface the first failure. `std-forms` depends on this library for field-level validation.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.validation": "0.1.0"
+```
+
+## API Reference
+
+### Types
+
+#### `ValidationError`
+
+```
+type ValidationError { field: String, message: String }
+```
+
+#### `ValidationResult`
+
+```
+type ValidationResult { valid: Int, error_field: String, error_message: String }
+```
+
+- `valid` — `1` if the rule passed, `0` if it failed
+- `error_field` — the field name on failure, `""` on success
+- `error_message` — a short description of what failed, `""` on success
+
+### Functions
+
+#### String rules
+
+##### `validate_required(field: String, value: String) -> ValidationResult`
+
+Fails if `value` is an empty string.
+
+**Example**
+```
+fn main() -> Int {
+  let r: ValidationResult = validate_required("email", "")
+  r.valid
+}
+```
+
+##### `validate_not_empty(field: String, value: String) -> ValidationResult`
+
+Alias for `validate_required`.
+
+##### `validate_min_length(field: String, value: String, min: Int) -> ValidationResult`
+
+Fails if the string length is less than `min`.
+
+##### `validate_max_length(field: String, value: String, max: Int) -> ValidationResult`
+
+Fails if the string length exceeds `max`.
+
+##### `validate_numeric(field: String, value: String) -> ValidationResult`
+
+Fails if `value` cannot be parsed as an integer.
+
+##### `validate_equals(field: String, actual: String, expected: String) -> ValidationResult`
+
+Fails if `actual != expected`. Use for password confirmation fields.
+
+#### Integer rules
+
+##### `validate_min_value(field: String, value: Int, min: Int) -> ValidationResult`
+
+Fails if `value < min`.
+
+##### `validate_max_value(field: String, value: Int, max: Int) -> ValidationResult`
+
+Fails if `value > max`.
+
+#### Composition
+
+##### `validation_ok() -> ValidationResult`
+
+Returns a pre-built passing result. Use as the initial accumulator in a chain.
+
+##### `validation_fail(field: String, message: String) -> ValidationResult`
+
+Returns a pre-built failing result with a custom message.
+
+##### `validation_merge(a: ValidationResult, b: ValidationResult) -> ValidationResult`
+
+Returns `a` if it failed, otherwise returns `b`. Use to apply rules in priority order and surface the first failure.
+
+**Example: chaining multiple rules**
+```
+fn main() -> Int {
+  let r1: ValidationResult = validate_required("username", "alice")
+  let r2: ValidationResult = validate_min_length("username", "alice", 3)
+  let r3: ValidationResult = validate_max_length("username", "alice", 20)
+  let result: ValidationResult = validation_merge(validation_merge(r1, r2), r3)
+  result.valid
+}
+```
+
+## Capabilities
+
+None. All functions are pure.
+
+## Notes / Limitations
+
+- `string_length` is a runtime built-in; the stub in `core.ax` returns `0` and is replaced at compile time.
+- `validate_numeric` uses `try_parse_int` (a pattern-matching built-in); the library does not support float parsing.
+- `validation_merge` returns the first failure only — it does not accumulate multiple errors. If you need to collect all errors, maintain a list of `ValidationResult` in your app state.

--- a/docs/stdlib-graduation-tracker.md
+++ b/docs/stdlib-graduation-tracker.md
@@ -30,25 +30,25 @@ A graduated package gets:
 ## Current cycle (2026-04-29)
 
 The 11 v0.x packages were assessed against the 4 criteria. **Zero
-packages graduate this cycle.** The same two criteria fail across
-the entire stdlib: no `examples/workflows/*` references the
-packages by name, and no per-package reference doc exists. Closing
-either alone is not sufficient; both are blockers. Filed as Wave-3
-follow-up work.
+packages graduate this cycle.** Criterion (4) reference docs is now
+closed: all 11 per-package pages exist under
+`docs/reference/stdlib/`. The remaining blocker is criterion (1):
+no `examples/workflows/*` workflow references any `std-*` package
+by name. Filed as Wave-3 follow-up work.
 
 | Package | (1) ex wf | (2) tests | (3) API stable | (4) docs | Decision |
 |---------|:---------:|:---------:|:--------------:|:--------:|----------|
-| `std-ui` | ✗ | ✓ (`std_ui_runs`) | ✓ | ✗ | Held — needs example workflow + `docs/reference/stdlib/std-ui.md` |
-| `std-validation` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-forms` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-authz` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-http` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-db` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-sync` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-routing` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-storage` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-notifications` | ✗ | ✓ | ✓ | ✗ | Held — same |
-| `std-testing` | ✗ | ✓ | ✓ | ✗ | Held — same |
+| `std-ui` | ✗ | ✓ (`std_ui_runs`) | ✓ | ✓ | Held — needs example workflow |
+| `std-validation` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-forms` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-authz` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-http` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-db` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-sync` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-routing` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-storage` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-notifications` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
+| `std-testing` | ✗ | ✓ | ✓ | ✓ | Held — needs example workflow |
 
 ### Per-criterion notes
 


### PR DESCRIPTION
## Summary

Creates `docs/reference/stdlib/<name>.md` for all 11 standard library packages, closing the reference-docs graduation blocker tracked in `docs/stdlib-graduation-tracker.md`.

## Packages documented

`std-ui`, `std-forms`, `std-authz`, `std-http`, `std-db`, `std-sync`, `std-validation`, `std-routing`, `std-storage`, `std-notifications`, `std-testing`

Each page follows a consistent template: overview, installation snippet, full API reference (functions, types, constants), capabilities section, notes/limitations.

## Key findings

- 5 packages need capabilities: `std-http` (`net.fetch`), `std-db` (`db.query`), `std-sync` (`net.fetch`), `std-storage` (`fs.read`, `fs.write`), `std-notifications` (`time.now`)
- 6 packages are fully pure (zero capabilities)
- All packages produce `Effect` records rather than performing I/O directly — consistent with Boruna's determinism contract

## Also updated

- `docs/stdlib-graduation-tracker.md` — criterion (4) flipped ✗→✓ for all 11 packages
- `docs/README.md` — new "Standard Libraries" navigation section added

## Test plan

- [x] No code changes — `cargo test --workspace` passes trivially
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)