### PR TITLE
docs(post1-std-llm-json): reference docs and example workflows for std-llm and std-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Four new example workflows demonstrating stdlib package usage (`form_submission_pipeline`, `data_ingestion_pipeline`, `api_routing_workflow`); closes graduation criterion 1 for all 11 `std-*` packages
-
+- `docs/reference/stdlib/std-llm.md` and `docs/reference/stdlib/std-json.md` — reference docs closing criterion 4 for `std-llm` and `std-json`
+- `examples/workflows/llm_content_generator/` and `examples/workflows/json_data_transformer/` — example workflows closing criterion 1 for `std-llm` and `std-json`
 - **`boruna evidence diff`** — compare two evidence bundles side-by-side.
   Reports differences in step outputs, audit event counts, workflow metadata,
   and verification status. `--json` flag for machine-readable output.

--- a/docs/reference/stdlib/std-json.md
+++ b/docs/reference/stdlib/std-json.md
@@ -1,0 +1,109 @@
+# std-json
+
+> JSON-flavoured data extraction and manipulation utilities
+
+**Package:** `std.json`  **Version:** `0.1.0`  **Capabilities required:** none
+
+## Overview
+
+`std-json` provides pure-functional helpers for building JSON-formatted strings from typed Boruna values. It covers the four JSON scalar types (string, number, boolean, null), object wrapping, and array wrapping. Because it has no capability requirements it can be used in any step regardless of policy. All functions are deterministic and produce no side effects.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.json": "0.1.0"
+```
+
+No capability grants are required.
+
+## API Reference
+
+### Types
+
+#### `JsonResult`
+
+```
+type JsonResult { ok: Bool, value: String, error: String }
+```
+
+A tagged result for operations that may fail. When `ok` is `true`, `value` holds the result; when `false`, `error` holds the reason.
+
+### Functions
+
+#### Result constructors
+
+##### `json_ok(value: String) -> JsonResult`
+
+Wraps a successful string result in a `JsonResult` with `ok = true`.
+
+##### `json_err(error: String) -> JsonResult`
+
+Wraps an error message in a `JsonResult` with `ok = false`.
+
+#### Field serialisers
+
+##### `json_string_field(key: String, value: String) -> String`
+
+Returns a JSON key-value fragment for a string value: `"key": "value"`.
+
+**Example**
+
+```
+fn main() -> Int {
+  let field: String = json_string_field("name", "Alice")
+  // field == "\"name\": \"Alice\""
+  let obj: String = json_object(field)
+  // obj == "{\"name\": \"Alice\"}"
+  0
+}
+```
+
+##### `json_int_field(key: String, value: Int) -> String`
+
+Returns a JSON key-value fragment for an integer value: `"key": <n>`. Calls the `int_to_string` stub internally; see Notes.
+
+##### `json_bool_field(key: String, value: Bool) -> String`
+
+Returns a JSON key-value fragment for a boolean value: `"key": true` or `"key": false`.
+
+##### `json_null_field(key: String) -> String`
+
+Returns a JSON key-value fragment for a null value: `"key": null`.
+
+#### Container builders
+
+##### `json_object(fields: String) -> String`
+
+Wraps a pre-serialised fields string in `{...}`. Combine multiple fields with string concatenation before passing.
+
+##### `json_array_wrap(items: String) -> String`
+
+Wraps a pre-serialised items string in `[...]`.
+
+#### Utilities
+
+##### `json_escape(s: String) -> String`
+
+Identity function — returns `s` unchanged. Char-level escaping requires character iteration which is not yet available in the language.
+
+##### `int_to_string(n: Int) -> String`
+
+Stub — returns `""`. Real integer-to-string conversion requires compiler support not yet landed.
+
+## Capabilities
+
+None. `std-json` is pure-functional with no side effects.
+
+## Notes / Limitations
+
+- `json_int_field` relies on `int_to_string`, which is currently a stub returning `""`. Integer fields will have an empty value until compiler support lands.
+- `json_escape` is an identity function; do not rely on it to sanitise strings containing `"` or `\`.
+- There is no recursive structure support; callers must build nested JSON by concatenating field strings manually before passing to `json_object`.
+
+## Version History
+
+| Version | Change |
+|---------|--------|
+| `0.1.0` | Initial release. `JsonResult` type; `json_ok`, `json_err`, `json_string_field`, `json_int_field`, `json_bool_field`, `json_null_field`, `json_object`, `json_array_wrap`, `json_escape`, `int_to_string`. |

--- a/docs/reference/stdlib/std-llm.md
+++ b/docs/reference/stdlib/std-llm.md
@@ -1,0 +1,94 @@
+# std-llm
+
+> Typed LLM effect wrappers for prompting and structured generation
+
+**Package:** `std.llm`  **Version:** `0.1.0`  **Capabilities required:** `llm.call`
+
+## Overview
+
+`std-llm` wraps LLM calls as typed `Effect` values. Your `update` handler returns these effects; the Boruna runtime dispatches them through the `llm.call` capability and delivers responses back via the named `callback_tag`. This keeps model I/O out of pure logic and makes every prompt auditable in the evidence bundle. Temperature is stored as `Int * 100` (e.g. `72` = `0.72`) to avoid floating-point precision issues.
+
+## Installation
+
+Add to your `package.ax.json` dependencies:
+
+```json
+"std.llm": "0.1.0"
+```
+
+Your workflow or app policy must grant `llm.call` to the step that uses this library.
+
+## API Reference
+
+### Types
+
+#### `Effect`
+
+```
+type Effect { kind: String, payload: String, callback_tag: String }
+```
+
+Returned by all request-building functions. Pass it back from `update` to trigger the LLM call. `kind` is either `"llm_call"` or `"llm_json_call"`.
+
+#### `LlmRequest`
+
+```
+type LlmRequest { system_prompt: String, user_prompt: String, max_tokens: Int, temperature: Int }
+```
+
+A fully described request for use with `llm_call` or `llm_json_call`. `temperature` is `Int * 100` (e.g. `72` = `0.72`).
+
+#### `LlmResponse`
+
+```
+type LlmResponse { content: String, tokens_used: Int, finish_reason: String }
+```
+
+Shape of the response delivered to the `callback_tag` handler.
+
+### Functions
+
+#### `llm_prompt(system: String, user: String, callback_tag: String) -> Effect`
+
+Convenience function: builds a default `LlmRequest` (1024 max tokens, temperature 0.72) and emits an `"llm_call"` effect.
+
+**Example**
+
+```
+fn main() -> Int {
+  let eff: Effect = llm_prompt(
+    "You are a helpful assistant.",
+    "Summarize this document.",
+    "summary_done"
+  )
+  0
+}
+```
+
+#### `llm_call(req: LlmRequest, callback_tag: String) -> Effect`
+
+Emits an `"llm_call"` effect from a fully specified `LlmRequest` — use when you need to control `max_tokens` or `temperature` explicitly.
+
+#### `llm_json_call(req: LlmRequest, callback_tag: String) -> Effect`
+
+Emits an `"llm_json_call"` effect, signalling to the runtime that the model should be prompted for structured JSON output.
+
+#### `default_llm_request(system: String, user: String) -> LlmRequest`
+
+Constructs an `LlmRequest` with default values: `max_tokens = 1024`, `temperature = 72`. Use when you want to inspect or mutate the request before passing it to `llm_call`.
+
+## Capabilities
+
+Requires `llm.call`. The VM's `CapabilityGateway` enforces this at runtime; the call is rejected if the active policy does not include `llm.call`.
+
+## Notes / Limitations
+
+- All functions produce `Effect` values — they do not perform any I/O themselves. Actual model calls happen in the runtime after the `update` function returns.
+- `temperature` is encoded as `Int * 100`; `72` means `0.72`. There is no float conversion in-language.
+- The `payload` field of the produced `Effect` is `system_prompt ++ "|" ++ user_prompt`; the runtime splits on `|` to reconstruct the two prompts.
+
+## Version History
+
+| Version | Change |
+|---------|--------|
+| `0.1.0` | Initial release. `LlmRequest`, `LlmResponse`, `Effect` types; `llm_call`, `llm_prompt`, `llm_json_call`, `default_llm_request` functions. |

--- a/docs/stdlib-graduation-tracker.md
+++ b/docs/stdlib-graduation-tracker.md
@@ -29,15 +29,14 @@ A graduated package gets:
 
 ## Current cycle (2026-04-29)
 
-The 11 v0.x packages were assessed against the 4 criteria. **All 11
-packages now meet all 4 criteria.** Criterion (1) is closed: three
-new example workflows (`form_submission_pipeline`,
-`data_ingestion_pipeline`, `api_routing_workflow`) collectively
-reference all 11 `std-*` packages. Version bumps (0.1.0 → 1.0.0)
-will happen in a follow-on release PR.
+The 11 original v0.x packages all meet all 4 criteria; version bumps
+(0.1.0 → 1.0.0) will happen in a follow-on release PR. Two new 0.x
+packages (`std-llm`, `std-json`) meet criteria 1, 2, and 4; held on
+criterion 3 (4-week API stability window). All 13 reference docs now
+exist under `docs/reference/stdlib/`.
 
-Two new 0.x packages were added this cycle: `std-llm` and `std-json`.
-These close the roadmap item `Expanded stdlib — std-llm, std-json libraries`.
+Two new 0.x packages were added this cycle: `std-llm` and `std-json`,
+closing the roadmap item `Expanded stdlib — std-llm, std-json libraries`.
 
 | Package | (1) ex wf | (2) tests | (3) API stable | (4) docs | Decision |
 |---------|:---------:|:---------:|:--------------:|:--------:|----------|
@@ -52,8 +51,8 @@ These close the roadmap item `Expanded stdlib — std-llm, std-json libraries`.
 | `std-storage` | ✓ | ✓ | ✓ | ✓ | Graduated (all 4 criteria met) |
 | `std-notifications` | ✓ | ✓ | ✓ | ✓ | Graduated (all 4 criteria met) |
 | `std-testing` | ✓ | ✓ | ✓ | ✓ | Graduated (all 4 criteria met) |
-| `std-llm` | ✗ | ✓ | ✓ | ✗ | New 0.x — needs example workflow + docs page |
-| `std-json` | ✗ | ✓ | ✓ | ✗ | New 0.x — needs example workflow + docs page |
+| `std-llm` | ✓ | ✓ | ✓ | ✓ | Held — needs 4-week API stability window (criterion 3) |
+| `std-json` | ✓ | ✓ | ✓ | ✓ | Held — needs 4-week API stability window (criterion 3) |
 
 ### Per-criterion notes
 

--- a/examples/workflows/json_data_transformer/steps/transform.ax
+++ b/examples/workflows/json_data_transformer/steps/transform.ax
@@ -1,0 +1,44 @@
+// Inline from std.json — import pending full package resolver integration
+
+type JsonResult { ok: Bool, value: String, error: String }
+
+fn json_ok(value: String) -> JsonResult {
+    JsonResult { ok: true, value: value, error: "" }
+}
+
+fn json_err(error: String) -> JsonResult {
+    JsonResult { ok: false, value: "", error: error }
+}
+
+fn json_string_field(key: String, value: String) -> String {
+    "\"" ++ key ++ "\": \"" ++ value ++ "\""
+}
+
+fn json_bool_field(key: String, value: Bool) -> String {
+    if value {
+        "\"" ++ key ++ "\": true"
+    } else {
+        "\"" ++ key ++ "\": false"
+    }
+}
+
+fn json_null_field(key: String) -> String {
+    "\"" ++ key ++ "\": null"
+}
+
+fn json_object(fields: String) -> String {
+    "{" ++ fields ++ "}"
+}
+
+fn json_array_wrap(items: String) -> String {
+    "[" ++ items ++ "]"
+}
+
+fn main() -> Int {
+    let name_field: String = json_string_field("name", "Alice")
+    let role_field: String = json_string_field("role", "engineer")
+    let active_field: String = json_bool_field("active", true)
+    let obj: String = json_object(name_field ++ ", " ++ role_field ++ ", " ++ active_field)
+    let result: JsonResult = json_ok(obj)
+    0
+}

--- a/examples/workflows/json_data_transformer/workflow.json
+++ b/examples/workflows/json_data_transformer/workflow.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "name": "json-data-transformer",
+  "version": "1.0.0",
+  "description": "Demonstrates std-json: serialises a data record to a JSON-formatted string.",
+  "steps": {
+    "transform": {
+      "kind": "source",
+      "source": "steps/transform.ax",
+      "capabilities": [],
+      "outputs": { "result": "String" }
+    }
+  },
+  "edges": []
+}

--- a/examples/workflows/llm_content_generator/steps/generate.ax
+++ b/examples/workflows/llm_content_generator/steps/generate.ax
@@ -1,0 +1,36 @@
+// Inline from std.llm — import pending full package resolver integration
+
+type Effect { kind: String, payload: String, callback_tag: String }
+
+type LlmRequest { system_prompt: String, user_prompt: String, max_tokens: Int, temperature: Int }
+
+type LlmResponse { content: String, tokens_used: Int, finish_reason: String }
+
+fn llm_call(req: LlmRequest, callback_tag: String) -> Effect {
+    let payload: String = req.system_prompt ++ "|" ++ req.user_prompt
+    Effect { kind: "llm_call", payload: payload, callback_tag: callback_tag }
+}
+
+fn llm_prompt(system: String, user: String, callback_tag: String) -> Effect {
+    let req: LlmRequest = LlmRequest { system_prompt: system, user_prompt: user, max_tokens: 1024, temperature: 72 }
+    llm_call(req, callback_tag)
+}
+
+fn llm_json_call(req: LlmRequest, callback_tag: String) -> Effect {
+    let payload: String = req.system_prompt ++ "|" ++ req.user_prompt
+    Effect { kind: "llm_json_call", payload: payload, callback_tag: callback_tag }
+}
+
+fn default_llm_request(system: String, user: String) -> LlmRequest {
+    LlmRequest { system_prompt: system, user_prompt: user, max_tokens: 1024, temperature: 72 }
+}
+
+fn main() -> Int {
+    let topic: String = "renewable energy"
+    let eff: Effect = llm_prompt(
+        "You are a content writer. Generate a short article.",
+        "Write a 200-word article about: " ++ topic,
+        "content_generated"
+    )
+    0
+}

--- a/examples/workflows/llm_content_generator/workflow.json
+++ b/examples/workflows/llm_content_generator/workflow.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "name": "llm-content-generator",
+  "version": "1.0.0",
+  "description": "Demonstrates std-llm: builds an LLM prompt effect for content generation.",
+  "steps": {
+    "generate": {
+      "kind": "source",
+      "source": "steps/generate.ax",
+      "capabilities": ["llm.call"],
+      "outputs": { "result": "String" }
+    }
+  },
+  "edges": []
+}


### PR DESCRIPTION
## Summary
- Adds `docs/reference/stdlib/std-llm.md` and `docs/reference/stdlib/std-json.md`
- Adds `examples/workflows/llm_content_generator/` and `examples/workflows/json_data_transformer/`
- Closes graduation criteria 1 and 4 for `std-llm` and `std-json`
- Both packages now Held only on criterion 3 (4-week API stability window)

## Test plan
- [ ] `boruna workflow validate examples/workflows/llm_content_generator`
- [ ] `boruna workflow validate examples/workflows/json_data_transformer`
- [ ] `cargo test --workspace -q` — all pass
- [ ] Graduation tracker updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)