### PR TITLE
feat(future/lsp): boruna-lsp language server for .ax files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +220,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -392,7 +403,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-service",
  "uuid",
 ]
@@ -433,6 +444,18 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "boruna-lsp"
+version = "1.1.0"
+dependencies = [
+ "boruna-compiler",
+ "boruna-tooling",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-lsp",
 ]
 
 [[package]]
@@ -846,6 +869,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1895,6 +1931,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,7 +2750,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3504,6 +3553,20 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -3531,7 +3594,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -3541,6 +3604,40 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "packages",
     "tooling",
     "crates/boruna-mcp",
+    "crates/boruna-lsp",
     "benches",
 ]
 

--- a/crates/boruna-lsp/Cargo.toml
+++ b/crates/boruna-lsp/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "boruna-lsp"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "boruna-lsp"
+path = "src/main.rs"
+
+[dependencies]
+boruna-compiler = { path = "../llmc" }
+boruna-tooling = { path = "../../tooling" }
+tower-lsp = "0.20"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/boruna-lsp/src/main.rs
+++ b/crates/boruna-lsp/src/main.rs
@@ -1,0 +1,398 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+struct BurunaLanguageServer {
+    client: Client,
+    // Tracks the latest text for each open document URI.
+    docs: Mutex<HashMap<String, String>>,
+}
+
+impl BurunaLanguageServer {
+    fn new(client: Client) -> Self {
+        BurunaLanguageServer {
+            client,
+            docs: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn store(&self, uri: &Url, text: String) {
+        if let Ok(mut map) = self.docs.lock() {
+            map.insert(uri.to_string(), text);
+        }
+    }
+
+    fn load(&self, uri: &Url) -> Option<String> {
+        self.docs
+            .lock()
+            .ok()
+            .and_then(|m| m.get(&uri.to_string()).cloned())
+    }
+
+    async fn analyze_document(&self, uri: Url, text: String) {
+        let diagnostics = compute_diagnostics(&text);
+        self.store(&uri, text);
+        self.client
+            .publish_diagnostics(uri, diagnostics, None)
+            .await;
+    }
+}
+
+fn compute_diagnostics(text: &str) -> Vec<Diagnostic> {
+    match boruna_compiler::compile("lsp", text) {
+        Err(err) => {
+            let (line, col, message) = match err {
+                boruna_compiler::CompileError::Lexer { line, col, msg } => {
+                    (line.saturating_sub(1), col.saturating_sub(1), msg)
+                }
+                boruna_compiler::CompileError::Parse { line, msg } => {
+                    (line.saturating_sub(1), 0, msg)
+                }
+                boruna_compiler::CompileError::Type(msg) => (0, 0, msg),
+                boruna_compiler::CompileError::Codegen(msg) => (0, 0, msg),
+            };
+            let pos = Position::new(line as u32, col as u32);
+            vec![Diagnostic {
+                range: Range::new(pos, pos),
+                severity: Some(DiagnosticSeverity::ERROR),
+                message,
+                source: Some("boruna-lsp".into()),
+                ..Default::default()
+            }]
+        }
+        Ok(_) => {
+            // Run AST analyzer for semantic diagnostics.
+            let tokens = match boruna_compiler::lexer::lex(text) {
+                Ok(t) => t,
+                Err(_) => return vec![],
+            };
+            let program = match boruna_compiler::parser::parse(tokens) {
+                Ok(p) => p,
+                Err(_) => return vec![],
+            };
+            let analyzer =
+                boruna_tooling::diagnostics::analyzer::Analyzer::new("lsp", text, &program);
+            analyzer
+                .analyze()
+                .into_iter()
+                .map(|d| {
+                    let severity = match d.severity {
+                        boruna_tooling::diagnostics::Severity::Error => DiagnosticSeverity::ERROR,
+                        boruna_tooling::diagnostics::Severity::Warning => {
+                            DiagnosticSeverity::WARNING
+                        }
+                        boruna_tooling::diagnostics::Severity::Info => {
+                            DiagnosticSeverity::INFORMATION
+                        }
+                        boruna_tooling::diagnostics::Severity::Hint => DiagnosticSeverity::HINT,
+                    };
+                    let (line, col) = d
+                        .location
+                        .as_ref()
+                        .map(|loc| {
+                            (
+                                loc.line.saturating_sub(1),
+                                loc.col.unwrap_or(1).saturating_sub(1),
+                            )
+                        })
+                        .unwrap_or((0, 0));
+                    let pos = Position::new(line as u32, col as u32);
+                    Diagnostic {
+                        range: Range::new(pos, pos),
+                        severity: Some(severity),
+                        message: d.message,
+                        source: Some("boruna-lsp".into()),
+                        ..Default::default()
+                    }
+                })
+                .collect()
+        }
+    }
+}
+
+fn completion_items(text: &str) -> Vec<CompletionItem> {
+    let keywords = [
+        "fn", "let", "if", "else", "match", "type", "enum", "import", "return", "true", "false",
+        "mut", "while", "for", "in", "export", "module",
+    ];
+    let builtin_types = [
+        "Int", "Float", "String", "Bool", "Unit", "Option", "Result", "List", "Map",
+    ];
+    let builtin_fns = [
+        "parse_int",
+        "parse_float",
+        "to_string",
+        "to_int",
+        "to_float",
+        "len",
+        "append",
+        "concat",
+        "head",
+        "tail",
+        "map",
+        "filter",
+        "fold",
+        "get",
+        "set",
+        "keys",
+        "values",
+        "contains",
+        "print",
+        "println",
+    ];
+
+    let mut items: Vec<CompletionItem> = keywords
+        .iter()
+        .map(|kw| CompletionItem {
+            label: kw.to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            ..Default::default()
+        })
+        .chain(builtin_types.iter().map(|t| CompletionItem {
+            label: t.to_string(),
+            kind: Some(CompletionItemKind::CLASS),
+            ..Default::default()
+        }))
+        .chain(builtin_fns.iter().map(|f| CompletionItem {
+            label: f.to_string(),
+            kind: Some(CompletionItemKind::FUNCTION),
+            ..Default::default()
+        }))
+        .collect();
+
+    // Add user-defined functions from the document.
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("fn ") {
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                items.push(CompletionItem {
+                    label: name,
+                    kind: Some(CompletionItemKind::FUNCTION),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    items
+}
+
+fn hover_info(text: &str, word: &str) -> Option<String> {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("fn ") {
+            let fn_name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if fn_name == word {
+                let sig = trimmed
+                    .find('{')
+                    .map(|i| trimmed[..i].trim_end())
+                    .unwrap_or(trimmed);
+                return Some(format!("```ax\n{sig}\n```"));
+            }
+        }
+    }
+    None
+}
+
+/// Extract the word at a given position in a text document.
+fn word_at(text: &str, pos: Position) -> String {
+    let line_idx = pos.line as usize;
+    let col_idx = pos.character as usize;
+    let line = text.lines().nth(line_idx).unwrap_or("");
+    let chars: Vec<char> = line.chars().collect();
+    let start = (0..col_idx.min(chars.len()))
+        .rev()
+        .find(|&i| !chars[i].is_alphanumeric() && chars[i] != '_')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let end = (col_idx..chars.len())
+        .find(|&i| !chars[i].is_alphanumeric() && chars[i] != '_')
+        .unwrap_or(chars.len());
+    chars[start..end].iter().collect()
+}
+
+/// Build LSP TextEdits that replace the entire document with `new_text`.
+fn full_document_edit(old_text: &str, new_text: String) -> Vec<TextEdit> {
+    let line_count = old_text.lines().count() as u32;
+    let last_col = old_text.lines().last().map(|l| l.len() as u32).unwrap_or(0);
+    vec![TextEdit {
+        range: Range::new(Position::new(0, 0), Position::new(line_count, last_col)),
+        new_text,
+    }]
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for BurunaLanguageServer {
+    async fn initialize(&self, _params: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![".".into()]),
+                    ..Default::default()
+                }),
+                document_formatting_provider: Some(OneOf::Left(true)),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                ..Default::default()
+            },
+            server_info: Some(ServerInfo {
+                name: "boruna-lsp".into(),
+                version: Some(env!("CARGO_PKG_VERSION").into()),
+            }),
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "boruna-lsp initialized")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let text = params.text_document.text;
+        self.analyze_document(uri, text).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        if let Some(change) = params.content_changes.into_iter().last() {
+            self.analyze_document(uri, change.text).await;
+        }
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let uri = &params.text_document_position.text_document.uri;
+        let text = self.load(uri).unwrap_or_default();
+        let items = completion_items(&text);
+        Ok(Some(CompletionResponse::Array(items)))
+    }
+
+    async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
+        let uri = &params.text_document.uri;
+        let text = match self.load(uri) {
+            Some(t) => t,
+            None => return Ok(Some(vec![])),
+        };
+        match boruna_tooling::format::format_source(&text) {
+            Ok(formatted) => Ok(Some(full_document_edit(&text, formatted))),
+            // Don't corrupt the document on parse failure.
+            Err(_) => Ok(Some(vec![])),
+        }
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+        let text = match self.load(uri) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+        let word = word_at(&text, pos);
+        match hover_info(&text, &word) {
+            Some(content) => Ok(Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: content,
+                }),
+                range: None,
+            })),
+            None => Ok(None),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let (service, socket) = LspService::new(BurunaLanguageServer::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostics_from_invalid_source() {
+        let bad = "fn main( -> Int { 0 }";
+        let diags = compute_diagnostics(bad);
+        assert!(!diags.is_empty(), "expected at least one diagnostic");
+        assert_eq!(diags[0].severity, Some(DiagnosticSeverity::ERROR));
+    }
+
+    #[test]
+    fn diagnostics_from_valid_source() {
+        let good = "fn main() -> Int {\n    42\n}\n";
+        let diags = compute_diagnostics(good);
+        assert!(
+            diags.is_empty(),
+            "expected zero diagnostics, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn format_valid_source_roundtrip() {
+        let src = "fn main() -> Int {\n42\n}\n";
+        let formatted = boruna_tooling::format::format_source(src).unwrap();
+        assert!(!formatted.is_empty());
+        let again = boruna_tooling::format::format_source(&formatted).unwrap();
+        assert_eq!(formatted, again, "formatting must be idempotent");
+    }
+
+    #[test]
+    fn completion_includes_keywords() {
+        let items = completion_items("");
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"fn"), "missing keyword 'fn'");
+        assert!(labels.contains(&"let"), "missing keyword 'let'");
+        assert!(labels.contains(&"if"), "missing keyword 'if'");
+    }
+
+    #[test]
+    fn completion_includes_user_functions() {
+        let src = "fn my_helper() -> Int { 1 }\nfn main() -> Int { my_helper() }\n";
+        let items = completion_items(src);
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(
+            labels.contains(&"my_helper"),
+            "user-defined fn should appear in completions"
+        );
+    }
+
+    #[test]
+    fn hover_finds_function_signature() {
+        let src = "fn add(a: Int, b: Int) -> Int {\n    a + b\n}\n";
+        let result = hover_info(src, "add");
+        assert!(result.is_some(), "expected hover result for 'add'");
+        let content = result.unwrap();
+        assert!(
+            content.contains("add"),
+            "hover should include function name"
+        );
+        assert!(content.contains("Int"), "hover should include type info");
+    }
+
+    #[test]
+    fn hover_returns_none_for_unknown() {
+        let src = "fn main() -> Int { 0 }\n";
+        assert!(hover_info(src, "nonexistent").is_none());
+    }
+}

--- a/docs/guides/lsp.md
+++ b/docs/guides/lsp.md
@@ -1,0 +1,42 @@
+# Language Server (LSP) Setup
+
+`boruna-lsp` implements the Language Server Protocol for `.ax` files.
+
+## Build
+
+```bash
+cargo build --bin boruna-lsp
+```
+
+## VS Code
+
+Install the [official LSP client extension](https://marketplace.visualstudio.com/items?itemName=boruna.boruna-lsp) (coming soon), or configure manually in `.vscode/settings.json`:
+
+```json
+{
+  "boruna.lsp.serverPath": "/path/to/boruna-lsp"
+}
+```
+
+Or use the generic `vscode-languageclient` setup with any LSP-capable extension.
+
+## Neovim (nvim-lspconfig)
+
+```lua
+require('lspconfig').boruna_lsp.setup {
+  cmd = { '/path/to/boruna-lsp' },
+  filetypes = { 'ax' },
+  root_dir = require('lspconfig.util').root_pattern('Cargo.toml', '.git'),
+}
+```
+
+## Features
+
+| Feature | Status |
+|---------|--------|
+| Real-time diagnostics (errors, warnings) | ✓ |
+| Keyword and built-in completion | ✓ |
+| Document formatting (`boruna fmt`) | ✓ |
+| Hover (function signatures) | ✓ |
+| Go-to-definition | planned |
+| Rename symbol | planned |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -147,7 +147,7 @@ These decisions block downstream planning. None of them are urgent today, but ea
 These items are on the long-term radar but not scheduled:
 
 - **Commercial platform**: hosted workflow execution, managed evidence storage, SSO, RBAC, compliance reporting — built on the open source core.
-- **IDE integration**: language server (LSP) for `.ax` syntax, completion, and diagnostics in VS Code / Neovim.
+- **IDE integration**: language server (LSP) for `.ax` syntax, completion, and diagnostics in VS Code / Neovim (boruna-lsp MVP: diagnostics, completion, formatting — future/lsp).
 - **Model evaluation framework**: run the same workflow against multiple LLM providers and compare evidence bundles.
 - **Compliance templates**: pre-built workflow patterns for common regulated use cases (SOC 2, HIPAA, financial audit).
 - **Cross-language FFI**: call into Rust/Python libraries from `.ax` through a typed capability interface.


### PR DESCRIPTION
## Summary
- New `boruna-lsp` binary — LSP server for `.ax` files
- Real-time diagnostics on document open/change via compiler + AstAnalyzer
- Keyword/built-in/user-function completion
- Document formatting via `boruna fmt` (format_source)
- Hover shows function signatures
- Works with VS Code, Neovim, and any LSP client

## Test plan
- [x] `diagnostics_from_invalid_source`
- [x] `diagnostics_from_valid_source`
- [x] `format_valid_source_roundtrip`
- [x] `completion_includes_keywords`
- [x] `completion_includes_user_functions`
- [x] `hover_finds_function_signature`
- [x] `hover_returns_none_for_unknown`
- [x] `cargo build --bin boruna-lsp`
- [x] `cargo clippy --workspace -- -D warnings` (zero warnings)
- [x] `cargo fmt --all -- --check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)