### PR TITLE
docs/ci: stdlib LTS entries, CLAUDE.md update, blob CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,31 @@ jobs:
         # adds <30s on a warm cache.
         run: cargo bench -p boruna-benches --no-run
 
+  blob-integration:
+    name: Blob integration (testcontainers)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-blob-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-blob-
+
+      - name: S3 integration tests (MinIO via testcontainers)
+        run: cargo test -p boruna-orchestrator --features s3-it -- --test-threads=1
+
+      - name: GCS integration tests (fake-gcs-server via testcontainers)
+        run: cargo test -p boruna-orchestrator --features gcs-it -- --test-threads=1
+
   clippy:
     name: Clippy
     runs-on: self-hosted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,8 @@ Note: directory paths still use original names (crates/llmbc, crates/llmc, etc.)
 
 ### Standard Libraries (libs/)
 
-11 deterministic libraries, each with `package.ax.json` and `src/core.ax`:
-std-ui, std-forms, std-authz, std-http, std-db, std-sync, std-validation, std-routing, std-storage, std-notifications, std-testing.
+13 deterministic libraries, each with `package.ax.json` and `src/core.ax`:
+std-ui, std-forms, std-authz, std-http, std-db, std-sync, std-validation, std-routing, std-storage, std-notifications, std-testing (all 1.0-stable as of v1.2.0), plus std-llm and std-json (0.1.0, Experimental).
 
 All are pure-functional (no hidden side effects). Libraries needing capabilities declare them in their manifest (e.g., std-http requires `net.fetch`, std-db requires `db.query`).
 

--- a/docs/lts.md
+++ b/docs/lts.md
@@ -100,6 +100,28 @@ allowed; removals and renames are not.
   contract) is LTS-protected. Field additions allowed; removals and renames
   require 2.0.
 
+### B.8 Standard library packages (`libs/`)
+
+The following `std-*` packages are 1.0-stable and LTS-protected from **v1.2.0**:
+
+| Package | Stable since | Reference docs |
+|---------|-------------|----------------|
+| `std-ui` | v1.2.0 | [`docs/reference/stdlib/std-ui.md`](./reference/stdlib/std-ui.md) |
+| `std-validation` | v1.2.0 | [`docs/reference/stdlib/std-validation.md`](./reference/stdlib/std-validation.md) |
+| `std-forms` | v1.2.0 | [`docs/reference/stdlib/std-forms.md`](./reference/stdlib/std-forms.md) |
+| `std-authz` | v1.2.0 | [`docs/reference/stdlib/std-authz.md`](./reference/stdlib/std-authz.md) |
+| `std-http` | v1.2.0 | [`docs/reference/stdlib/std-http.md`](./reference/stdlib/std-http.md) |
+| `std-db` | v1.2.0 | [`docs/reference/stdlib/std-db.md`](./reference/stdlib/std-db.md) |
+| `std-sync` | v1.2.0 | [`docs/reference/stdlib/std-sync.md`](./reference/stdlib/std-sync.md) |
+| `std-routing` | v1.2.0 | [`docs/reference/stdlib/std-routing.md`](./reference/stdlib/std-routing.md) |
+| `std-storage` | v1.2.0 | [`docs/reference/stdlib/std-storage.md`](./reference/stdlib/std-storage.md) |
+| `std-notifications` | v1.2.0 | [`docs/reference/stdlib/std-notifications.md`](./reference/stdlib/std-notifications.md) |
+| `std-testing` | v1.2.0 | [`docs/reference/stdlib/std-testing.md`](./reference/stdlib/std-testing.md) |
+
+LTS guarantees for these packages: function signatures, parameter types, and return types are frozen. New functions may be added in minor releases. Capability requirements in `package.ax.json` are frozen.
+
+**Not yet LTS-protected**: `std-llm` and `std-json` are at `0.1.0` (Experimental tier); they graduate when the 4-week API stability window closes (eligible ≥ 2026-05-27).
+
 ## What CAN change in 1.x
 
 The following are **not** part of the LTS contract and may evolve in minor


### PR DESCRIPTION
## Summary

- Adds 11 graduated `std-*` packages to `docs/lts.md` as a new **B.8** section, marking them LTS-protected from v1.2.0. Notes `std-llm` and `std-json` as Experimental (not yet LTS).
- Updates `CLAUDE.md` stdlib count from 11 to 13, listing the two new Experimental packages.
- Wires `s3-it` and `gcs-it` testcontainers integration tests into CI as a new `blob-integration` job running on `ubuntu-latest` (Docker available by default).

## Test plan

- [ ] `blob-integration` job runs `cargo test -p boruna-orchestrator --features s3-it` and `--features gcs-it` with `--test-threads=1`
- [ ] Feature flags `s3-it` and `gcs-it` confirmed present in `orchestrator/Cargo.toml`
- [ ] Test files `s3_integration.rs` and `gcs_integration.rs` confirmed present in `orchestrator/tests/`
- [ ] `docs/lts.md` B.8 section renders correctly with the 11-package table
- [ ] Existing CI jobs (`test`, `clippy`, `fmt`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)