### PR TITLE
feat(lang): string built-ins (int_to_string, float_to_string, string_len, string_chars)

### DIFF
--- a/crates/llmbc/src/opcode.rs
+++ b/crates/llmbc/src/opcode.rs
@@ -121,6 +121,18 @@ pub enum Op {
     /// Pop a string, push Result: Ok(Int) on success, Err(String) on failure.
     TryParseInt,
 
+    /// Pop an Int, push its decimal String representation.
+    IntToString,
+
+    /// Pop a Float, push its decimal String representation.
+    FloatToString,
+
+    /// Pop a String, push its byte length as Int.
+    StringLen,
+
+    /// Pop a String, push a List of single-character Strings.
+    StringChars,
+
     /// No operation.
     Nop,
 
@@ -178,6 +190,10 @@ impl Op {
             Op::StrContains => 0x85,
             Op::StrStartsWith => 0x86,
             Op::TryParseInt => 0x87,
+            Op::IntToString => 0x88,
+            Op::FloatToString => 0x89,
+            Op::StringLen => 0x8A,
+            Op::StringChars => 0x8B,
             Op::Nop => 0xFE,
             Op::Halt => 0xFF,
         }

--- a/crates/llmc/src/codegen.rs
+++ b/crates/llmc/src/codegen.rs
@@ -294,6 +294,26 @@ impl Emitter {
                             fe.code.push(Op::StrStartsWith);
                             return Ok(());
                         }
+                        "__builtin_int_to_string" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::IntToString);
+                            return Ok(());
+                        }
+                        "__builtin_float_to_string" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::FloatToString);
+                            return Ok(());
+                        }
+                        "__builtin_string_len" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::StringLen);
+                            return Ok(());
+                        }
+                        "__builtin_string_chars" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::StringChars);
+                            return Ok(());
+                        }
                         // 0.3-S14: builtin `step_input(name)` reads a
                         // workflow step's resolved upstream output.
                         // Emits `Op::CapCall(StepInput, 1)` which

--- a/crates/llmc/src/typeck.rs
+++ b/crates/llmc/src/typeck.rs
@@ -53,6 +53,10 @@ impl TypeChecker {
         functions.insert("try_parse_int".to_string(), 1);
         functions.insert("str_contains".to_string(), 2);
         functions.insert("str_starts_with".to_string(), 2);
+        functions.insert("__builtin_int_to_string".to_string(), 1);
+        functions.insert("__builtin_float_to_string".to_string(), 1);
+        functions.insert("__builtin_string_len".to_string(), 1);
+        functions.insert("__builtin_string_chars".to_string(), 1);
         // 0.3-S14: read a workflow step's resolved input value at
         // runtime. Compiles to `Op::CapCall(StepInput, 1)` which
         // dispatches through the gateway's StepInputHandler. Returns

--- a/crates/llmvm/src/tests.rs
+++ b/crates/llmvm/src/tests.rs
@@ -2045,4 +2045,84 @@ mod tests {
             "pure program must leave cap events empty"
         );
     }
+
+    // ── New string built-in tests ──
+
+    #[test]
+    fn test_int_to_string() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::IntToString, Op::Ret],
+            vec![Value::Int(42)],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::String("42".into())
+        );
+    }
+
+    #[test]
+    fn test_int_to_string_negative() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::IntToString, Op::Ret],
+            vec![Value::Int(-7)],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::String("-7".into())
+        );
+    }
+
+    #[test]
+    fn test_float_to_string() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::FloatToString, Op::Ret],
+            vec![Value::Float(3.14)],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::String("3.14".into())
+        );
+    }
+
+    #[test]
+    fn test_string_len() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::StringLen, Op::Ret],
+            vec![Value::String("hello".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Int(5));
+    }
+
+    #[test]
+    fn test_string_len_empty() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::StringLen, Op::Ret],
+            vec![Value::String("".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Int(0));
+    }
+
+    #[test]
+    fn test_string_chars() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::StringChars, Op::Ret],
+            vec![Value::String("ab".into())],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::List(vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_string_chars_empty() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::StringChars, Op::Ret],
+            vec![Value::String("".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::List(vec![]));
+    }
 }

--- a/crates/llmvm/src/vm.rs
+++ b/crates/llmvm/src/vm.rs
@@ -897,6 +897,58 @@ impl Vm {
                         }
                     }
                 }
+                Op::IntToString => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::Int(n) => self.push(Value::String(format!("{n}")))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "Int",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::FloatToString => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::Float(f) => self.push(Value::String(format!("{f}")))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "Float",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringLen => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::String(s) => self.push(Value::Int(s.len() as i64))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringChars => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::String(s) => {
+                            let chars: Vec<Value> =
+                                s.chars().map(|c| Value::String(c.to_string())).collect();
+                            self.push(Value::List(chars))?;
+                        }
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
                 Op::Nop => {}
                 Op::Halt => {
                     return Ok(self.stack.pop().unwrap_or(Value::Unit));

--- a/libs/std-json/src/core.ax
+++ b/libs/std-json/src/core.ax
@@ -1,7 +1,5 @@
 // std.json — JSON-flavoured data extraction and manipulation utilities
 // Pure-functional. No capabilities required. No side effects.
-// Note: json_escape is an identity for now; the language lacks char iteration.
-// Note: json_int_field uses int_to_string stub; real int formatting requires compiler support.
 
 type JsonResult { ok: Bool, value: String, error: String }
 
@@ -41,14 +39,33 @@ fn json_array_wrap(items: String) -> String {
     "[" ++ items ++ "]"
 }
 
+fn escape_char(c: String) -> String {
+    if c == "\\" {
+        "\\\\"
+    } else {
+        if c == "\"" {
+            "\\\""
+        } else {
+            c
+        }
+    }
+}
+
 fn json_escape(s: String) -> String {
-    // Identity: char-level escaping requires iteration not yet in the language.
-    s
+    let chars: List<String> = __builtin_string_chars(s)
+    let result: String = ""
+    let i: Int = 0
+    let n: Int = list_len(chars)
+    while i < n {
+        let c: String = list_get(chars, i)
+        result = result ++ escape_char(c)
+        i = i + 1
+    }
+    result
 }
 
 fn int_to_string(n: Int) -> String {
-    // Built-in stub: returns empty string; real conversion requires compiler support.
-    ""
+    __builtin_int_to_string(n)
 }
 
 fn main() -> Int {


### PR DESCRIPTION
## Summary

- Adds four language built-ins compiled to dedicated opcodes: `IntToString`, `FloatToString`, `StringLen`, `StringChars`
- Built-ins are registered in the type checker under `__builtin_*` names to avoid naming conflicts with user-defined library functions
- Fixes the two `std-json` stubs: `int_to_string` now delegates to `__builtin_int_to_string`, and `json_escape` iterates chars via `__builtin_string_chars` + `escape_char` to produce correct `\` and `"` escaping

## Naming approach

Built-ins use the `__builtin_` prefix in the compiler/typeck to avoid the recursive self-call problem that would arise if the stdlib's `int_to_string` called a built-in of the same name. The stdlib wrappers have clean user-facing names; the primitives are internal.

## Test plan

- [x] `cargo test -p boruna-vm` — 146 tests pass, including 7 new tests for the 4 built-in opcodes
- [x] `cargo test -p boruna-compiler` — 69 tests pass
- [x] `cargo test -p boruna-tooling` — 138 tests pass, including `test_std_json_runs` and `test_std_json_determinism`
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)