### PR TITLE
docs(reference): cli.md + ax-language.md for new commands and built-ins

### DIFF
--- a/docs/reference/ax-language.md
+++ b/docs/reference/ax-language.md
@@ -228,6 +228,42 @@ Err("message")
 { "key": "value" }
 ```
 
+## Import statements
+
+```ax
+import "std-name"
+```
+
+Import statements load a standard library package at compile time. The library source is inlined into the compilation unit before type-checking. The import line itself is removed from the compiled output.
+
+Standard library packages are resolved from the `libs/` directory relative to the current working directory.
+
+Example:
+
+```ax
+import "std-json"
+
+fn main() -> Int {
+    let s: String = int_to_string(42)
+    0
+}
+```
+
+## Built-in functions
+
+These functions are provided by the runtime and do not need to be imported:
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `__builtin_int_to_string` | `(Int) -> String` | Convert an integer to its decimal string representation |
+| `__builtin_float_to_string` | `(Float) -> String` | Convert a float to its string representation |
+| `__builtin_string_len` | `(String) -> Int` | Length of a string in bytes |
+| `__builtin_string_chars` | `(String) -> List<String>` | Split a string into a list of single-character strings |
+
+These built-ins are also wrapped in `std-json` (via `int_to_string`, `json_escape`) and can be called directly in any `.ax` file.
+
+**Note on naming:** The `__builtin_` prefix distinguishes these from user-defined functions and prevents shadowing. User-facing wrappers in stdlib packages use cleaner names.
+
 ## What .ax is not
 
 `.ax` is deliberately minimal. It does not have:
@@ -236,6 +272,5 @@ Err("message")
 - Exceptions (use `Result<T, E>`)
 - Implicit side effects (every effect must be declared)
 - Generics (types are concrete at definition time)
-- Modules/imports (capability is via the standard library system)
 
 These omissions are intentional. They keep the language deterministic and auditable.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -229,35 +229,99 @@ cargo run --features boruna-cli/http --bin boruna -- \
   --policy allow-all --live --record
 ```
 
+### `boruna workflow schedule`
+
+Run a workflow on a cron schedule. Loops until SIGINT (Ctrl-C).
+
+```bash
+boruna workflow schedule <workflow-dir/> [options]
+
+Options:
+  --cron <expr>            5-field cron expression (required), e.g. "*/5 * * * *"
+  --policy <name>          Capability policy (default: deny-all)
+  --data-dir <dir>         Directory for runs.db and per-run output (default: .boruna/data)
+  --max-concurrency <n>    Maximum concurrent runs; skips tick if a run is already active (default: 1)
+  --live                   Enable real capability handlers (requires http feature)
+```
+
+When a scheduled tick fires while a previous run is still active, that tick is skipped.
+
+### `boruna workflow eval`
+
+Run a workflow against two LLM provider configurations and compare evidence bundles.
+
+```bash
+boruna workflow eval <workflow-dir/> --providers-a <file.json> --providers-b <file.json> [options]
+
+Options:
+  --providers-a <file>     First provider config JSON file (required)
+  --providers-b <file>     Second provider config JSON file (required)
+  --runs <n>               Runs per provider (default: 1)
+  --data-dir <dir>         Directory for evidence bundles
+  --json                   Machine-readable output
+```
+
+Reports per-step output agreement and timing differences between the two provider sets.
+
+### `boruna workflow find`
+
+Recursively discover `workflow.json` files under a directory tree.
+
+```bash
+boruna workflow find [dir] [--json]
+```
+
+Validates each discovered workflow and prints path, name, step count, and validity. `dir` defaults to the current directory. Use `--json` for a JSON array.
+
 ---
 
 ## `boruna evidence`
 
-Inspect and verify evidence bundles.
+Inspect, verify, and manage evidence bundles.
 
 ```bash
-boruna evidence inspect <bundle-dir/> [--json]
-boruna evidence verify <bundle-dir/>
+boruna evidence create <run-id> --output-dir <dir> [--data-dir <dir>]
+boruna evidence verify <bundle-dir/> [--bundle-encryption-key <hex>]
+boruna evidence inspect <bundle-dir/> [--json] [--decrypt] [--bundle-encryption-key <hex>]
+boruna evidence diff <bundle-a> <bundle-b> [--json]
+boruna evidence gc-blobs [--data-dir <dir>] [--dry-run] [--json]
+boruna evidence serve <bundle-dir/> [--port <port>]
+boruna evidence rotate-kek <target> --old-kek <hex> --new-kek <hex> [options]
 ```
 
 Examples:
 
 ```bash
+# Build a bundle from a completed run
+boruna evidence create abc123def456 --output-dir ./bundles
+
+# Inspect a bundle
 boruna evidence inspect .boruna/runs/20260315-143022-abc4d/
 boruna evidence inspect .boruna/runs/20260315-143022-abc4d/ --json
+
+# Verify a bundle
 boruna evidence verify .boruna/runs/20260315-143022-abc4d/
 ```
 
+### evidence create
+
+Build an evidence bundle from a persisted run. Reads the run's metadata, step checkpoints, and hash-chained audit log; writes a bundle directory with `workflow.json`, `policy.json`, per-step outputs, `audit_log.json`, `env_fingerprint.json`, and `manifest.json`. Bundles are created on demand — the runner does not auto-create them.
+
+```bash
+boruna evidence create <run-id> --output-dir <dir> [--data-dir <dir>]
+```
+
+The bundle is written to `<output-dir>/<run-id>/`.
+
 ### evidence diff
 
-Compare two evidence bundles.
+Compare two evidence bundles side-by-side.
 
 ```
 boruna evidence diff <bundle-a> <bundle-b> [--json]
 ```
 
-Reports differences in workflow metadata, step outputs, audit event counts, and
-verification status. Use `--json` for machine-readable output.
+Reports differences in workflow metadata, step outputs, audit event counts, and verification status. Use `--json` for machine-readable output.
 
 Examples:
 
@@ -265,6 +329,46 @@ Examples:
 boruna evidence diff .boruna/runs/run-baseline/ .boruna/runs/run-rerun/
 boruna evidence diff baseline/ rerun/ --json
 ```
+
+### evidence gc-blobs
+
+Sweep orphaned content-addressed blobs from the data directory.
+
+```bash
+boruna evidence gc-blobs [--data-dir <dir>] [--dry-run] [--json]
+```
+
+An orphan is a blob file no longer referenced by any run checkpoint. Reports `{deleted, skipped, bytes_freed}`. Use `--dry-run` to report without deleting.
+
+### evidence serve
+
+Start a local web UI to browse an evidence bundle.
+
+```bash
+boruna evidence serve <bundle-dir/> [--port <port>]
+```
+
+Serves a read-only inspector at `http://localhost:<port>` (default: 4444). Requires the `serve` feature:
+
+```bash
+cargo run --features boruna-cli/serve --bin boruna -- evidence serve ./bundles/my-run/
+```
+
+### evidence rotate-kek
+
+Rotate the key-encryption key (KEK) on one or more encrypted bundles without re-encrypting file content.
+
+```bash
+boruna evidence rotate-kek <target> --old-kek <hex> --new-kek <hex> [options]
+
+Options:
+  --kek-id-from <id>     Only rotate bundles whose current kek_id matches (safety check)
+  --kek-id-to <id>       kek_id written to the rotated manifest (default: "default")
+  --dry-run              Print planned actions without modifying any bundle
+  --parallelism <n>      Parallel bundle limit in batch mode (default: min(8, num_cpus))
+```
+
+`<target>` may be a single bundle directory or a parent directory whose immediate subdirectories are bundles (batch mode).
 
 ---
 

--- a/docs/reference/stdlib/std-json.md
+++ b/docs/reference/stdlib/std-json.md
@@ -62,7 +62,7 @@ fn main() -> Int {
 
 ##### `json_int_field(key: String, value: Int) -> String`
 
-Returns a JSON key-value fragment for an integer value: `"key": <n>`. Calls the `int_to_string` stub internally; see Notes.
+Returns a JSON key-value fragment for an integer value: `"key": <n>`.
 
 ##### `json_bool_field(key: String, value: Bool) -> String`
 
@@ -86,20 +86,18 @@ Wraps a pre-serialised items string in `[...]`.
 
 ##### `json_escape(s: String) -> String`
 
-Identity function — returns `s` unchanged. Char-level escaping requires character iteration which is not yet available in the language.
+Escapes a string for safe inclusion in a JSON value. Correctly escapes `"` and `\` characters.
 
 ##### `int_to_string(n: Int) -> String`
 
-Stub — returns `""`. Real integer-to-string conversion requires compiler support not yet landed.
+Converts an integer to its decimal string representation. Wraps `__builtin_int_to_string`.
 
 ## Capabilities
 
 None. `std-json` is pure-functional with no side effects.
 
-## Notes / Limitations
+## Notes
 
-- `json_int_field` relies on `int_to_string`, which is currently a stub returning `""`. Integer fields will have an empty value until compiler support lands.
-- `json_escape` is an identity function; do not rely on it to sanitise strings containing `"` or `\`.
 - There is no recursive structure support; callers must build nested JSON by concatenating field strings manually before passing to `json_object`.
 
 ## Version History


### PR DESCRIPTION
## Summary

- `docs/reference/cli.md`: adds `boruna workflow schedule`, `eval`, `find`; adds `boruna evidence create`, `gc-blobs`, `serve`, `rotate-kek` (diff was already present, complete evidence section now consolidated)
- `docs/reference/ax-language.md`: adds **Import statements** and **Built-in functions** sections covering `__builtin_int_to_string`, `__builtin_float_to_string`, `__builtin_string_len`, `__builtin_string_chars`; removes stale "no modules/imports" bullet from "What .ax is not"
- `docs/reference/stdlib/std-json.md`: removes stub notes for `int_to_string` and `json_escape`, reflects current working implementations

## Test plan

- [ ] `cargo check --workspace` passes (confirmed clean before commit)
- [ ] Spot-check that `boruna workflow schedule --help` output matches the documented flags
- [ ] Spot-check that `boruna evidence gc-blobs --help` matches the documented flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)