### PR TITLE
feat(evidence): boruna evidence inspect --decrypt decrypts step output payloads

### DIFF
--- a/crates/llmvm-cli/src/main.rs
+++ b/crates/llmvm-cli/src/main.rs
@@ -3981,8 +3981,9 @@ fn run_evidence(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use boruna_orchestrator::audit::{
         evidence::{BundleJson, BundleManifest},
-        resolve_kek,
+        parse_kek_hex, resolve_kek,
         verify::verify_bundle_with_kek,
+        Envelope,
     };
 
     match cmd {
@@ -4048,31 +4049,82 @@ fn run_evidence(
                 .ok()
                 .and_then(|s| serde_json::from_str(&s).ok());
 
-            // Sprint W6-B: refuse to print decrypted payloads from
-            // an encrypted bundle unless the operator opted in via
-            // --decrypt. The manifest itself is plaintext metadata;
-            // it always prints. Currently `inspect` only prints
-            // manifest-level fields (no payload), so the gate is
-            // future-proofing — wire it now so the surface lands
-            // with the encryption sprint.
-            let _ = (decrypt, bundle_encryption_key);
-            if let Some(info) = &manifest.encryption {
-                if !decrypt {
-                    eprintln!(
-                        "note: bundle is encrypted (algorithm={}, kek_id={}); \
-                         pass --decrypt to print decrypted file contents",
-                        info.algorithm, info.kek_id
-                    );
-                }
-            }
+            // Resolve decrypted step outputs when --decrypt is passed.
+            let step_outputs: Option<std::collections::BTreeMap<String, serde_json::Value>> =
+                if decrypt {
+                    match &manifest.encryption {
+                        None => {
+                            eprintln!(
+                                "note: --decrypt passed but bundle is not encrypted; ignoring"
+                            );
+                            None
+                        }
+                        Some(enc_info) => {
+                            let kek_hex = bundle_encryption_key
+                                .as_deref()
+                                .ok_or("--decrypt requires --bundle-encryption-key <hex>")?;
+                            let kek = parse_kek_hex(kek_hex)
+                                .map_err(|e| format!("invalid KEK: {e}"))?;
+                            let envelope = Envelope::unwrap(enc_info, &kek)
+                                .map_err(|e| format!("error: KEK unwrap failed: {e}"))?;
+
+                            let mut outputs =
+                                std::collections::BTreeMap::<String, serde_json::Value>::new();
+                            for filename in &enc_info.files {
+                                // Only surface step outputs (outputs/<step>/<name>.json)
+                                if !filename.starts_with("outputs/") {
+                                    continue;
+                                }
+                                let path = dir.join(filename);
+                                let ciphertext = fs::read(&path).map_err(|e| {
+                                    format!("error: cannot read {filename}: {e}")
+                                })?;
+                                let plaintext =
+                                    envelope.decrypt_file(filename, &ciphertext).map_err(|e| {
+                                        format!("error: decryption failed for {filename}: {e}")
+                                    })?;
+                                let content = String::from_utf8(plaintext).map_err(|e| {
+                                    format!(
+                                        "error: decrypted content of {filename} is not UTF-8: {e}"
+                                    )
+                                })?;
+                                // Use step_id/name as key, stripping "outputs/" prefix
+                                // and ".json" suffix for readability.
+                                let key = filename
+                                    .trim_start_matches("outputs/")
+                                    .trim_end_matches(".json")
+                                    .to_string();
+                                let val: serde_json::Value =
+                                    serde_json::from_str(&content).unwrap_or_else(|_| {
+                                        serde_json::Value::String(content.clone())
+                                    });
+                                outputs.insert(key, val);
+                            }
+                            Some(outputs)
+                        }
+                    }
+                } else {
+                    // No --decrypt: hint that content is hidden if encrypted.
+                    if let Some(info) = &manifest.encryption {
+                        eprintln!(
+                            "note: bundle is encrypted (algorithm={}, kek_id={}); \
+                             pass --decrypt to print decrypted file contents",
+                            info.algorithm, info.kek_id
+                        );
+                    }
+                    None
+                };
 
             if json {
-                let merged = serde_json::json!({
+                let mut merged = serde_json::json!({
                     "format_version": bundle_meta
                         .as_ref()
                         .map(|b| b.format_version.clone()),
                     "manifest": manifest,
                 });
+                if let Some(outputs) = step_outputs {
+                    merged["step_outputs"] = serde_json::to_value(outputs)?;
+                }
                 println!("{}", serde_json::to_string_pretty(&merged)?);
             } else {
                 println!("=== Evidence Bundle ===");
@@ -4105,6 +4157,12 @@ fn run_evidence(
                     "  os: {}/{}",
                     manifest.env_fingerprint.os, manifest.env_fingerprint.arch
                 );
+                if let Some(outputs) = step_outputs {
+                    println!("\n=== Step Outputs (decrypted) ===");
+                    for (key, val) in &outputs {
+                        println!("{key}: {val}");
+                    }
+                }
             }
         }
         EvidenceCommand::GcBlobs {

--- a/crates/llmvm-cli/tests/cli_evidence_inspect_decrypt.rs
+++ b/crates/llmvm-cli/tests/cli_evidence_inspect_decrypt.rs
@@ -124,15 +124,9 @@ fn inspect_does_not_leak_plaintext_without_decrypt_flag() {
 }
 
 #[test]
-fn inspect_decrypt_flag_is_inert_when_payload_display_unimplemented() {
-    // Regression guard for the current behavior: today `inspect`
-    // does NOT print decrypted payloads even with --decrypt, because
-    // payload preview is not implemented. The flag is wired through
-    // the CLI for future-proofing. This test pins that behavior so a
-    // future change adding payload display is forced to update both
-    // the gate AND this test.
+fn inspect_decrypt_reveals_step_outputs_with_correct_kek() {
     let dir = tempdir().unwrap();
-    let run_id = "R-decrypt-noop";
+    let run_id = "R-decrypt-reveal";
     build_encrypted_bundle(dir.path(), run_id);
     let bundle_dir = dir.path().join(run_id);
 
@@ -155,22 +149,68 @@ fn inspect_decrypt_flag_is_inert_when_payload_display_unimplemented() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let combined = format!(
-        "{}\n{}",
-        String::from_utf8_lossy(&output.stdout),
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // With --decrypt and the correct KEK the canary MUST appear.
+    assert!(
+        stdout.contains(PLAINTEXT_CANARY),
+        "stdout should contain the plaintext canary when --decrypt + correct KEK is used; \
+         stdout was: {stdout}"
+    );
+
+    // The step-outputs section header must be present.
+    assert!(
+        stdout.contains("Step Outputs (decrypted)"),
+        "stdout should contain section header; stdout was: {stdout}"
+    );
+}
+
+#[test]
+fn inspect_decrypt_on_plaintext_bundle_prints_warning() {
+    // When --decrypt is passed against a non-encrypted bundle, the CLI
+    // should print a warning and exit 0 (not fail).
+    let dir = tempdir().unwrap();
+    let run_id = "R-decrypt-plaintext";
+
+    // Build a plaintext bundle (no .with_encryption).
+    let mut builder =
+        EvidenceBundleBuilder::new(dir.path(), run_id, "plaintext-test").unwrap();
+    builder.add_workflow_def(r#"{"name":"plain"}"#).unwrap();
+    builder.add_policy(r#"{"default_allow":true}"#).unwrap();
+    let mut audit = AuditLog::new();
+    audit.append(AuditEvent::WorkflowStarted {
+        workflow_hash: "wf".into(),
+        policy_hash: "pol".into(),
+    });
+    audit.append(AuditEvent::WorkflowCompleted {
+        result_hash: "res".into(),
+        total_duration_ms: 1,
+    });
+    builder.finalize(&audit).unwrap();
+
+    let bundle_dir = dir.path().join(run_id);
+    let output = Command::new(boruna_bin())
+        .args([
+            "evidence",
+            "inspect",
+            bundle_dir.to_str().unwrap(),
+            "--decrypt",
+            "--bundle-encryption-key",
+            "4242424242424242424242424242424242424242424242424242424242424242",
+        ])
+        .output()
+        .expect("inspect --decrypt on plaintext bundle failed to spawn");
+
+    assert!(
+        output.status.success(),
+        "inspect --decrypt on plaintext bundle should exit 0; status {:?}, stderr: {}",
+        output.status,
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Today: even WITH --decrypt, the canary should not appear
-    // because payload preview is unimplemented. If a future sprint
-    // adds payload display under --decrypt, change this assertion to
-    // require the canary IS present, and add a complementary
-    // assertion that without --decrypt it stays hidden.
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !combined.contains(PLAINTEXT_CANARY),
-        "current `inspect` is metadata-only; this test guards the \
-         contract. If a future change adds payload preview under \
-         --decrypt, update this assertion (and the no-flag test). \
-         combined output was: {combined}"
+        stderr.contains("not encrypted"),
+        "stderr should warn that bundle is not encrypted; got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

- Implements the W6-B `--decrypt` gate that was wired but not functional in `evidence inspect`
- When `--decrypt` and `--bundle-encryption-key <hex>` are passed, the handler unwraps the DEK with the supplied KEK and decrypts all step output files listed in `EncryptionInfo.files`
- Text mode adds `=== Step Outputs (decrypted) ===` section; `--json` mode adds a `"step_outputs"` map
- Passing `--decrypt` against a plaintext bundle prints `"note: --decrypt passed but bundle is not encrypted; ignoring"` and exits 0

## Test plan

- [ ] `inspect_does_not_leak_plaintext_without_decrypt_flag` — existing guard, still passes
- [ ] `inspect_decrypt_reveals_step_outputs_with_correct_kek` — new: asserts canary appears in stdout with correct KEK
- [ ] `inspect_decrypt_on_plaintext_bundle_prints_warning` — new: asserts warning when `--decrypt` on plaintext bundle
- [ ] `cargo clippy --workspace -- -D warnings` — zero warnings
- [ ] All 3 tests run under `--features boruna-cli/persist-sqlite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)