### PR TITLE
feat(lang): more string and list built-ins (14 new operations)

### DIFF
--- a/crates/llmbc/src/opcode.rs
+++ b/crates/llmbc/src/opcode.rs
@@ -133,6 +133,48 @@ pub enum Op {
     /// Pop a String, push a List of single-character Strings.
     StringChars,
 
+    /// Pop two strings (haystack, needle), push Bool.
+    StringContains,
+
+    /// Pop two strings (string, prefix), push Bool.
+    StringStartsWith,
+
+    /// Pop two strings (string, suffix), push Bool.
+    StringEndsWith,
+
+    /// Pop a String, push its uppercase version as String.
+    StringToUpper,
+
+    /// Pop a String, push its lowercase version as String.
+    StringToLower,
+
+    /// Pop a String, push its trimmed version as String.
+    StringTrim,
+
+    /// Pop a List<String> and a separator String, push joined String.
+    StringJoin,
+
+    /// Pop a List, push its length as Int.
+    ListLenBuiltin,
+
+    /// Pop a List, push Bool (true if empty).
+    ListIsEmpty,
+
+    /// Pop a List, push Option<T> (first element or None).
+    ListHead,
+
+    /// Pop a List, push List (all elements except first).
+    ListTail,
+
+    /// Pop a List and a value, push new List with value appended.
+    ListAppend,
+
+    /// Pop two Lists, push their concatenation.
+    ListConcat,
+
+    /// Pop a List, push reversed List.
+    ListReverse,
+
     /// No operation.
     Nop,
 
@@ -194,6 +236,20 @@ impl Op {
             Op::FloatToString => 0x89,
             Op::StringLen => 0x8A,
             Op::StringChars => 0x8B,
+            Op::StringContains => 0x8C,
+            Op::StringStartsWith => 0x8D,
+            Op::StringEndsWith => 0x8E,
+            Op::StringToUpper => 0x8F,
+            Op::StringToLower => 0x90,
+            Op::StringTrim => 0x91,
+            Op::StringJoin => 0x92,
+            Op::ListLenBuiltin => 0x93,
+            Op::ListIsEmpty => 0x94,
+            Op::ListHead => 0x95,
+            Op::ListTail => 0x96,
+            Op::ListAppend => 0x97,
+            Op::ListConcat => 0x98,
+            Op::ListReverse => 0x99,
             Op::Nop => 0xFE,
             Op::Halt => 0xFF,
         }

--- a/crates/llmc/src/codegen.rs
+++ b/crates/llmc/src/codegen.rs
@@ -314,6 +314,82 @@ impl Emitter {
                             fe.code.push(Op::StringChars);
                             return Ok(());
                         }
+                        "__builtin_string_contains" if args.len() == 2 => {
+                            self.emit_expr(&args[0], fe)?;
+                            self.emit_expr(&args[1], fe)?;
+                            fe.code.push(Op::StringContains);
+                            return Ok(());
+                        }
+                        "__builtin_string_starts_with" if args.len() == 2 => {
+                            self.emit_expr(&args[0], fe)?;
+                            self.emit_expr(&args[1], fe)?;
+                            fe.code.push(Op::StringStartsWith);
+                            return Ok(());
+                        }
+                        "__builtin_string_ends_with" if args.len() == 2 => {
+                            self.emit_expr(&args[0], fe)?;
+                            self.emit_expr(&args[1], fe)?;
+                            fe.code.push(Op::StringEndsWith);
+                            return Ok(());
+                        }
+                        "__builtin_string_to_upper" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::StringToUpper);
+                            return Ok(());
+                        }
+                        "__builtin_string_to_lower" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::StringToLower);
+                            return Ok(());
+                        }
+                        "__builtin_string_trim" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::StringTrim);
+                            return Ok(());
+                        }
+                        "__builtin_string_join" if args.len() == 2 => {
+                            self.emit_expr(&args[0], fe)?;
+                            self.emit_expr(&args[1], fe)?;
+                            fe.code.push(Op::StringJoin);
+                            return Ok(());
+                        }
+                        "__builtin_list_len" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::ListLenBuiltin);
+                            return Ok(());
+                        }
+                        "__builtin_list_is_empty" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::ListIsEmpty);
+                            return Ok(());
+                        }
+                        "__builtin_list_head" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::ListHead);
+                            return Ok(());
+                        }
+                        "__builtin_list_tail" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::ListTail);
+                            return Ok(());
+                        }
+                        "__builtin_list_append" if args.len() == 2 => {
+                            self.emit_expr(&args[0], fe)?;
+                            self.emit_expr(&args[1], fe)?;
+                            fe.code.push(Op::ListAppend);
+                            return Ok(());
+                        }
+                        "__builtin_list_concat" if args.len() == 2 => {
+                            self.emit_expr(&args[0], fe)?;
+                            self.emit_expr(&args[1], fe)?;
+                            fe.code.push(Op::ListConcat);
+                            return Ok(());
+                        }
+                        "__builtin_list_reverse" if args.len() == 1 => {
+                            self.emit_expr(&args[0], fe)?;
+                            fe.code.push(Op::ListReverse);
+                            return Ok(());
+                        }
                         // 0.3-S14: builtin `step_input(name)` reads a
                         // workflow step's resolved upstream output.
                         // Emits `Op::CapCall(StepInput, 1)` which

--- a/crates/llmc/src/typeck.rs
+++ b/crates/llmc/src/typeck.rs
@@ -57,6 +57,20 @@ impl TypeChecker {
         functions.insert("__builtin_float_to_string".to_string(), 1);
         functions.insert("__builtin_string_len".to_string(), 1);
         functions.insert("__builtin_string_chars".to_string(), 1);
+        functions.insert("__builtin_string_contains".to_string(), 2);
+        functions.insert("__builtin_string_starts_with".to_string(), 2);
+        functions.insert("__builtin_string_ends_with".to_string(), 2);
+        functions.insert("__builtin_string_to_upper".to_string(), 1);
+        functions.insert("__builtin_string_to_lower".to_string(), 1);
+        functions.insert("__builtin_string_trim".to_string(), 1);
+        functions.insert("__builtin_string_join".to_string(), 2);
+        functions.insert("__builtin_list_len".to_string(), 1);
+        functions.insert("__builtin_list_is_empty".to_string(), 1);
+        functions.insert("__builtin_list_head".to_string(), 1);
+        functions.insert("__builtin_list_tail".to_string(), 1);
+        functions.insert("__builtin_list_append".to_string(), 2);
+        functions.insert("__builtin_list_concat".to_string(), 2);
+        functions.insert("__builtin_list_reverse".to_string(), 1);
         // 0.3-S14: read a workflow step's resolved input value at
         // runtime. Compiles to `Op::CapCall(StepInput, 1)` which
         // dispatches through the gateway's StepInputHandler. Returns

--- a/crates/llmvm/src/tests.rs
+++ b/crates/llmvm/src/tests.rs
@@ -2125,4 +2125,242 @@ mod tests {
         );
         assert_eq!(run_module(module).unwrap(), Value::List(vec![]));
     }
+
+    // ── New string built-ins (post1/more-string-list-builtins) ──
+
+    #[test]
+    fn test_string_contains_true() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringContains, Op::Ret],
+            vec![Value::String("hello world".into()), Value::String("world".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(true));
+    }
+
+    #[test]
+    fn test_string_contains_false() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringContains, Op::Ret],
+            vec![Value::String("hello".into()), Value::String("xyz".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_string_starts_with_true() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringStartsWith, Op::Ret],
+            vec![Value::String("hello world".into()), Value::String("hello".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(true));
+    }
+
+    #[test]
+    fn test_string_starts_with_false() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringStartsWith, Op::Ret],
+            vec![Value::String("hello".into()), Value::String("world".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_string_ends_with_true() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringEndsWith, Op::Ret],
+            vec![Value::String("hello world".into()), Value::String("world".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(true));
+    }
+
+    #[test]
+    fn test_string_ends_with_false() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringEndsWith, Op::Ret],
+            vec![Value::String("hello".into()), Value::String("xyz".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_string_to_upper() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::StringToUpper, Op::Ret],
+            vec![Value::String("hello".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::String("HELLO".into()));
+    }
+
+    #[test]
+    fn test_string_to_lower() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::StringToLower, Op::Ret],
+            vec![Value::String("HELLO".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::String("hello".into()));
+    }
+
+    #[test]
+    fn test_string_trim() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::StringTrim, Op::Ret],
+            vec![Value::String("  hello  ".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::String("hello".into()));
+    }
+
+    #[test]
+    fn test_string_join() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringJoin, Op::Ret],
+            vec![
+                Value::List(vec![
+                    Value::String("a".into()),
+                    Value::String("b".into()),
+                    Value::String("c".into()),
+                ]),
+                Value::String(", ".into()),
+            ],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::String("a, b, c".into()));
+    }
+
+    #[test]
+    fn test_string_join_empty_list() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::StringJoin, Op::Ret],
+            vec![Value::List(vec![]), Value::String(",".into())],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::String("".into()));
+    }
+
+    // ── New list built-ins ──
+
+    #[test]
+    fn test_list_len_builtin() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListLenBuiltin, Op::Ret],
+            vec![Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+            ])],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Int(3));
+    }
+
+    #[test]
+    fn test_list_is_empty_true() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListIsEmpty, Op::Ret],
+            vec![Value::List(vec![])],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(true));
+    }
+
+    #[test]
+    fn test_list_is_empty_false() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListIsEmpty, Op::Ret],
+            vec![Value::List(vec![Value::Int(1)])],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_list_head_some() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListHead, Op::Ret],
+            vec![Value::List(vec![Value::Int(10), Value::Int(20)])],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::Some(Box::new(Value::Int(10)))
+        );
+    }
+
+    #[test]
+    fn test_list_head_none() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListHead, Op::Ret],
+            vec![Value::List(vec![])],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::None);
+    }
+
+    #[test]
+    fn test_list_tail() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListTail, Op::Ret],
+            vec![Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+            ])],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::List(vec![Value::Int(2), Value::Int(3)])
+        );
+    }
+
+    #[test]
+    fn test_list_tail_empty() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListTail, Op::Ret],
+            vec![Value::List(vec![])],
+        );
+        assert_eq!(run_module(module).unwrap(), Value::List(vec![]));
+    }
+
+    #[test]
+    fn test_list_append() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::ListAppend, Op::Ret],
+            vec![
+                Value::List(vec![Value::Int(1), Value::Int(2)]),
+                Value::Int(3),
+            ],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+        );
+    }
+
+    #[test]
+    fn test_list_concat() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::PushConst(1), Op::ListConcat, Op::Ret],
+            vec![
+                Value::List(vec![Value::Int(1), Value::Int(2)]),
+                Value::List(vec![Value::Int(3), Value::Int(4)]),
+            ],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+                Value::Int(4),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_list_reverse() {
+        let module = simple_module(
+            vec![Op::PushConst(0), Op::ListReverse, Op::Ret],
+            vec![Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+            ])],
+        );
+        assert_eq!(
+            run_module(module).unwrap(),
+            Value::List(vec![Value::Int(3), Value::Int(2), Value::Int(1)])
+        );
+    }
 }

--- a/crates/llmvm/src/vm.rs
+++ b/crates/llmvm/src/vm.rs
@@ -949,6 +949,250 @@ impl Vm {
                         }
                     }
                 }
+                Op::StringContains => {
+                    let needle = self.pop()?;
+                    let haystack = self.pop()?;
+                    match (haystack, needle) {
+                        (Value::String(h), Value::String(n)) => {
+                            self.push(Value::Bool(h.contains(n.as_str())))?;
+                        }
+                        (Value::String(_), b) => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: b.type_name(),
+                            })
+                        }
+                        (a, _) => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: a.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringStartsWith => {
+                    let prefix = self.pop()?;
+                    let string = self.pop()?;
+                    match (string, prefix) {
+                        (Value::String(s), Value::String(p)) => {
+                            self.push(Value::Bool(s.starts_with(p.as_str())))?;
+                        }
+                        (Value::String(_), b) => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: b.type_name(),
+                            })
+                        }
+                        (a, _) => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: a.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringEndsWith => {
+                    let suffix = self.pop()?;
+                    let string = self.pop()?;
+                    match (string, suffix) {
+                        (Value::String(s), Value::String(sfx)) => {
+                            self.push(Value::Bool(s.ends_with(sfx.as_str())))?;
+                        }
+                        (Value::String(_), b) => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: b.type_name(),
+                            })
+                        }
+                        (a, _) => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: a.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringToUpper => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::String(s) => self.push(Value::String(s.to_uppercase()))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringToLower => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::String(s) => self.push(Value::String(s.to_lowercase()))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringTrim => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::String(s) => self.push(Value::String(s.trim().to_string()))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::StringJoin => {
+                    let sep = self.pop()?;
+                    let list = self.pop()?;
+                    match (list, sep) {
+                        (Value::List(items), Value::String(separator)) => {
+                            let parts: Result<Vec<String>, VmError> = items
+                                .into_iter()
+                                .map(|v| match v {
+                                    Value::String(s) => Ok(s),
+                                    _ => Err(VmError::TypeError {
+                                        expected: "String",
+                                        got: v.type_name(),
+                                    }),
+                                })
+                                .collect();
+                            self.push(Value::String(parts?.join(&separator)))?;
+                        }
+                        (Value::List(_), b) => {
+                            return Err(VmError::TypeError {
+                                expected: "String",
+                                got: b.type_name(),
+                            })
+                        }
+                        (a, _) => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: a.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::ListLenBuiltin => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::List(items) => self.push(Value::Int(items.len() as i64))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::ListIsEmpty => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::List(items) => self.push(Value::Bool(items.is_empty()))?,
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::ListHead => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::List(items) => {
+                            let result = match items.into_iter().next() {
+                                Some(v) => Value::Some(Box::new(v)),
+                                None => Value::None,
+                            };
+                            self.push(result)?;
+                        }
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::ListTail => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::List(items) => {
+                            let tail = if items.is_empty() {
+                                vec![]
+                            } else {
+                                items[1..].to_vec()
+                            };
+                            self.push(Value::List(tail))?;
+                        }
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::ListAppend => {
+                    let item = self.pop()?;
+                    let val = self.pop()?;
+                    match val {
+                        Value::List(mut items) => {
+                            items.push(item);
+                            self.push(Value::List(items))?;
+                        }
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::ListConcat => {
+                    let b = self.pop()?;
+                    let a = self.pop()?;
+                    match (a, b) {
+                        (Value::List(mut la), Value::List(lb)) => {
+                            la.extend(lb);
+                            self.push(Value::List(la))?;
+                        }
+                        (Value::List(_), b) => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: b.type_name(),
+                            })
+                        }
+                        (a, _) => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: a.type_name(),
+                            })
+                        }
+                    }
+                }
+                Op::ListReverse => {
+                    let val = self.pop()?;
+                    match val {
+                        Value::List(items) => {
+                            let reversed: Vec<Value> = items.into_iter().rev().collect();
+                            self.push(Value::List(reversed))?;
+                        }
+                        _ => {
+                            return Err(VmError::TypeError {
+                                expected: "List",
+                                got: val.type_name(),
+                            })
+                        }
+                    }
+                }
                 Op::Nop => {}
                 Op::Halt => {
                     return Ok(self.stack.pop().unwrap_or(Value::Unit));


### PR DESCRIPTION
## Summary

- Adds 7 string built-ins: `__builtin_string_contains`, `__builtin_string_starts_with`, `__builtin_string_ends_with`, `__builtin_string_to_upper`, `__builtin_string_to_lower`, `__builtin_string_trim`, `__builtin_string_join`
- Adds 7 list built-ins: `__builtin_list_len`, `__builtin_list_is_empty`, `__builtin_list_head`, `__builtin_list_tail`, `__builtin_list_append`, `__builtin_list_concat`, `__builtin_list_reverse`
- Follows the `__builtin_*` pattern from #59: opcodes in `boruna-bytecode`, VM dispatch in `boruna-vm`, typeck registration and codegen dispatch in `boruna-compiler`
- Opcodes assigned byte tags 0x8C–0x99 (continuing from 0x8B = StringChars in #59)
- 21 new VM tests, all passing; clippy clean

## Test plan
- [x] `cargo test -p boruna-compiler` — 63 tests pass
- [x] `cargo test -p boruna-vm` — 167 tests pass (includes 21 new built-in tests)
- [x] `cargo test -p boruna-tooling` — 6 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)