### PR TITLE
ci: add concurrency groups to reduce artifact-storage buildup

### DIFF
--- a/.github/workflows/bench-compare.yml
+++ b/.github/workflows/bench-compare.yml
@@ -30,6 +30,10 @@ on:
       - 'LICENSE'
       - 'CHANGELOG.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/smoke-musl.yml
+++ b/.github/workflows/smoke-musl.yml
@@ -27,6 +27,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary

- **ci.yml** — add `concurrency` with `cancel-in-progress: true`. Per-push/PR runs on the same ref are cancelled when superseded, eliminating duplicate in-flight runs that would compound artifact storage.
- **bench-compare.yml** — same; PR-only trigger, each PR gets its own concurrency group.
- **release.yml** — add `concurrency` group **without** `cancel-in-progress` (set to `false`). Prevents double `workflow_dispatch` for the same tag from racing, but never cancels a mid-flight release publish. Release artifacts (`retention-days: 7`) left as-is — these are genuine release deliverables, not CI build binaries.
- **smoke-musl.yml** — same pattern as `release.yml` (rc-tag + workflow_dispatch). Small markdown reports left as-is.

## Background

Artifact storage peaked at ~307 MB from three target-triple build binaries (~100 MB each, 15 copies each: `aarch64-apple-darwin`, `aarch64-unknown-linux-musl`, `x86_64-unknown-linux-musl`). They self-expire at `retention-days: 7`, so current live storage is 0 MB — this is a preventive hygiene fix.

No artifact upload steps were modified. All four YAML files validated via `js-yaml`.

## Test plan

- [ ] Open a PR and confirm the CI run for the prior push to that branch is automatically cancelled
- [ ] Confirm bench-compare is similarly cancelled on force-push to the same PR
- [ ] Push a release tag and verify the release workflow runs to completion (no mid-flight cancellation)