### PR TITLE
feat(intent-evidence): capture intent declarations into evidence bundles (v1.6.0, Theme B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-07-15
+
+Sixth feature minor on the 1.x LTS line. First sprint of the agentlanguages.dev
+competitive-borrow program (Theme B): machine-read `intent` declarations captured
+into tamper-evident evidence bundles.
+
+### Added
+
+- **`intent "..."` declarations captured into evidence bundles.** Borrowed from **Pact** (intent-in-signature) and **Intent**/**Prove** (machine-read purpose), per the agentlanguages.dev competitive research (`claudedocs/research_agentlanguages_competitive_2026-07-15.md`, Theme B). A function may declare a single machine-read purpose after its signature: `fn transfer(x: Int) -> Int !{db.write} intent "Move funds between accounts" { ... }`. The clause is optional, order-independent with `requires`/`ensures`, and a second `intent` on one function is a parse error. Intent threads through lexer → AST (`FnDef.intent`) → codegen → bytecode (`Function.intent`, additive `#[serde(default)]` — pre-Sprint-1 modules load with `None`) and is surfaced in `boruna ast --json`. When a workflow runs, each source-kind step's `intent` is captured into the evidence bundle as `intents.json` (step_id → declared purpose), covered by the bundle's checksums and `bundle_hash` — so `evidence verify` fails if a captured intent is tampered, and an auditor sees what each step was *authorized* to do next to what it did. Determinism (§15): intent is replay-verified evidence, already transitively in `workflow_hash`. See `docs/design-intent-evidence.md`.
+
 ## [1.5.0] — 2026-05-20
 
 Fifth feature minor on the 1.x LTS line. Quint-inspired tooling additions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "boruna-benches"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-bytecode"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-cli"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "axum",
  "boruna-bytecode",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-compiler"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-vm",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-effect"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "serde",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-framework"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-lsp"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-compiler",
  "boruna-tooling",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-mcp"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-orchestrator"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-pkg"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-tooling"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-vm"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boruna-bytecode",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/escapeboy/boruna/actions/workflows/ci.yml/badge.svg)](https://github.com/escapeboy/boruna/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.6.0-blue.svg)](CHANGELOG.md)
 [![Status: Stable](https://img.shields.io/badge/status-stable-green.svg)](docs/stability.md)
 
 > **LTS — in force.** 1.x is the long-term-support line: through 2027-11-15 active and 2028-05-15 security. See [`docs/lts.md`](./docs/lts.md) for support windows, deprecation policy, and security-backport SLAs.

--- a/claudedocs/research_agentlanguages_competitive_2026-07-15.md
+++ b/claudedocs/research_agentlanguages_competitive_2026-07-15.md
@@ -1,0 +1,193 @@
+# Competitive Research — agentlanguages.dev catalogue
+
+**What ideas can Boruna borrow from the other 34 "AI-agent languages"?**
+
+- **Date:** 2026-07-15
+- **Source of truth:** [agentlanguages.dev](https://agentlanguages.dev/#catalogue) — "35 languages tracked," snapshot dated 13 Jul 2026
+- **Method:** Fetched the catalogue + Boruna's own analysis page, then fanned out 5 parallel research agents across all 34 non-Boruna entries. Each agent read the per-project analysis page (and repo/README where quick), extracted the single distinctive mechanism, and rated its borrow-value *for Boruna specifically* (given Boruna's profile and named gaps).
+- **Confidence:** Medium-High on the field map and per-project distinctive ideas (primary source is the catalogue's own analysis, which is opinionated but well-researched). Lower on exact maturity/benchmark numbers (several projects are preprints, thought experiments, or single-author early builds; a few self-disclaim correctness). **This is a research report — no implementation, no code, no architectural commitment. Recommendations are for human decision.**
+
+---
+
+## Executive summary
+
+The field splits into **three camps**: **Syntactic** (strip ambiguity from the surface — SSA, JSON ASTs, English-keyword operators), **Verification** (make the compiler catch semantic errors — contracts, refinement types, SMT/BMC proofs), and **Orchestration** (it's not a language problem — sequence, sandbox, audit, approve). Boruna sits in **Orchestration, tagged "also verification."** Its differentiator — capability-safe-by-construction execution + hash-chained tamper-evident evidence + deterministic replay for regulated industries — is **unique in the catalogue**. No other project owns the "prove exactly what ran to a regulator" position.
+
+Boruna's own analysis is flattering ("more carefully thought through than several entries with two orders of magnitude more attention") but its catalogue data is **stale** — it lists v0.2.0 / 34 commits / 557 tests, whereas the project is at **v1.5.0** with distributed execution, REPL, literate workflows, ITF export, and property-based `simulate`. Worth refreshing the listing.
+
+Across 34 projects, **5 rate High borrow-value, 2 Medium-High, 17 Medium, 4 Low, 6 None.** The High/Medium-High cluster is strikingly coherent: almost everything worth stealing pushes on Boruna's **two named gaps** — *no formal contracts/SMT* and *no uncertainty quantification* — or **deepens the auditability moat Boruna already owns**. Crucially, the best ideas slot into subsystems Boruna *already has* (typechecker, capability system, EventLog, evidence bundles, `simulate`/witness DSL, MCP server) rather than requiring a rewrite.
+
+**The five highest-value borrows:**
+
+| # | Idea | From | Slots into | Why it wins |
+|---|------|------|-----------|-------------|
+| 1 | **Optional contracts (`requires`/`ensures`) with graduated discharge** — typecheck → property `simulate` (already have) → SMT (Z3) for decidable fragments → runtime guard that logs to EventLog | Vera, Aver, Vow, Intent, MoonBit | typechecker + `simulate` + EventLog/evidence | Closes the #1 named gap, reuses the invariant/witness DSL, and a failed guard becomes a *replayable evidence event* — pure Boruna thesis |
+| 2 | **`intent`/`explain` annotations bound to machine-checked facts** — prose intent per step, compiler-verified to reference real contracts/capabilities (build fails on dangling/drifted reference), flowing into the evidence bundle | Pact, Intent, Prove, Aver | syntax + typechecker + literate workflows + evidence | Regulator gets "what was this step *supposed* to do" next to "what it did"; cheap; extends v1.5 literate workflows from unchecked narration to verified claims |
+| 3 | **LLM inference as a tracked typed effect + calibrated uncertainty** — promote `llm` from boolean capability to an effect the typechecker propagates up the call graph; wrap model outputs in conformal-prediction confidence sets with a policy-set target error rate, recorded in evidence | Vera, Quasar, Lumen | capability system + typechecker + evidence | Fills the uncertainty gap; "this step transitively calls a model, at this confidence" becomes a static, auditable fact |
+| 4 | **Analysis-gated approvals + typed recovery restarts** — approval fires only when static analysis *cannot prove* an effect is non-sensitive (cuts approval fatigue); failed steps surface named, policy-gated "restart" recovery options logged in the EventLog | Quasar, Pel | typechecker + distributed approval-gate + EventLog | Fewer, smarter human gates; richer than binary approve/reject; every choice stays in the evidence chain |
+| 5 | **Hardened agent-facing surface** — stable *versioned* diagnostic codes with `fix`+`retry` fields; deterministic **structural (JSON-Patch) quickfixes** recordable in evidence; a token-budgeted project-context MCP tool; an `llms.txt`; and a version-locked auto-generated agent skill | Codong, X07, Zero, Aver/Lume, NERD, Vow | diagnostics + MCP server + tooling | Cheap, self-contained wins that directly improve the agent-authoring loop Boruna already targets |
+
+**Reinforced (do NOT change):** Multiple projects independently converge on Boruna's existing choices — capability-explicit semantics, canonical/deterministic output, JSON diagnostics, VM-enforced determinism, separate human-readable surface over a bytecode IR. The catalogue also documents a **cautionary lesson** (B-IR's three failed attempts; the TBIR model that spontaneously rewrote control-character opcodes back into English): **do not token-golf `.ax` into a dense/alien syntax.** LLMs handle readable keywords *better*, and it would sacrifice the human-auditor half of Boruna's audience for a benefit Boruna doesn't need. Boruna's "syntax not token-optimized" gap is **safe to leave open.**
+
+---
+
+## The field, in one map
+
+```
+SYNTACTIC (representational)        VERIFICATION (semantic)              ORCHESTRATION (coordination)
+strip ambiguity from the surface   make the compiler catch errors       constrain how agents coordinate
+─────────────────────────────      ──────────────────────────────       ────────────────────────────────
+Magpie  (SSA-as-syntax)            MoonBit (real-time type sampler) ★    Boruna  (evidence + replay) ← us
+X07     (JSON ASTs)                Vera    (mandatory contracts+Z3) ★    Pel     (grammar-as-capability)
+NERD    (English-keyword ops)      Aver    (verify→prove ladder)         Quasar  (conformal prediction) ★
+Axis    (constrained decoding)     Intent  (verified_by no-drift)        Marsha  (LLM-as-compiler)
+Laze/Sever/Mog/Lume/Lumen…         Vow     (BMC + counterexamples)        Fabro   (Graphviz DOT workflows)
+                                   AILANG  (capability-row inference)     Plasm   (dry-run plan gate)
+                                   Prove   (verbs-as-effects; anti-AI)    Spec    (role-owned IR artefacts)
+                                   NanoLang(mandatory self-tests; Coq)    Plumbing(category-theoretic wiring)
+                                   Pact/Codex/Codong/Tacit/Zero/BHC…
+```
+
+The camps blur most around Boruna — it already spans Orchestration + Verification. That overlap is exactly where the borrowable ideas concentrate.
+
+---
+
+## Thematic synthesis — where the ideas cluster
+
+Instead of 34 disconnected suggestions, the borrow-worthy ideas group into **seven themes**. Themes A–C are the strategic ones (close named gaps / deepen the moat); D–G are tactical hardening.
+
+### Theme A — Formal contracts, discharged in tiers *(the #1 gap)*
+**Converging projects:** Vera (High), Aver (High), Vow (Med-High), Intent (High), MoonBit (Med), Prove (Med).
+
+The verification camp's whole thesis is Boruna's biggest missing piece. The consensus mechanism, adapted to Boruna:
+
+- Add **optional** `requires`/`ensures` (and loop `invariant`) contracts to `.ax`. Optional, not mandatory — Vera makes them mandatory, but Boruna's workflow-step model doesn't need that severity.
+- **Graduated discharge** (Vera's three-tier / Aver's ladder): decidable clauses → **SMT (Z3)** at compile time; the rest → **runtime guard**; and reuse Boruna's existing **property-based `simulate` + invariant/witness DSL** (v1.5) as the sampled middle tier. A clause's tier can be chosen automatically by which arithmetic fragment it lives in.
+- **A failed guard is an evidence event.** This is the Boruna-native twist (Vow's "counterexample = concrete replayable input + structured blame"): a violated contract drops a **hash-chained, re-runnable counterexample record** into the evidence bundle, replayable via ReplayEngine. That turns verification failures into auditable artifacts, not log lines — and upgrades `simulate` witnesses into first-class audit objects.
+- **Structured blame** (Vow): a `requires` violation faults the caller, an `ensures` violation the callee — useful in multi-step workflows.
+
+*Effort:* SMT integration is the heavy part (feature-flagged Z3, per ADR-001 dep discipline). The `simulate`-as-middle-tier and counterexample-as-evidence pieces are cheap and reuse existing code.
+
+### Theme B — Intent bound to machine-checked facts *(deepen the moat)*
+**Converging projects:** Pact (High), Intent (High), Prove (Med), Aver (High).
+
+Boruna proves *what ran*. These projects prove *what it was supposed to do* — and bind the two so they can't drift:
+
+- **`intent "..."` in the signature** (Pact): a first-class, machine-read intent string per `fn`/workflow-step, captured into the evidence hash chain. Trivial cost, direct regulator payoff.
+- **`verified_by` referential integrity** (Intent): the human-readable intent names the specific contracts/capabilities it relies on (`BankAccount.withdraw.requires`); the compiler resolves every reference in semantic analysis and **fails the build on a dangling one.** Prose provably cannot drift from the checked facts.
+- **Verified `explain` blocks** (Prove): controlled-natural-language docs parsed and checked against the called functions' declared effects/contracts.
+- **Net effect on v1.5 literate workflows:** upgrade markdown↔`.ax` literate prose from *unchecked narration* to *compiler-verified claims about a step's declared effects and intent.* This is the single most on-thesis, lowest-cost cluster.
+
+### Theme C — LLM effect as a typed, tracked, budgeted, calibrated thing *(the #2 gap)*
+**Converging projects:** Vera (High), Quasar (High), Lumen (Med).
+
+Boruna gates `llm` as a boolean capability. The field goes three steps further:
+
+- **Typed effect propagation** (Vera): make `llm` an effect the typechecker propagates *up the call graph*, so "this workflow step transitively invokes a model" is statically visible and surfaced in evidence — a small typechecker/capability change, large auditability payoff.
+- **Parameterized grants** (Lumen): attach numeric budgets to the authorization, not just a boolean — `!{llm.chat(max_tokens=1024)}` — producing quantifiable evidence entries for cost/usage governance.
+- **Calibrated uncertainty** (Quasar): wrap model outputs in **conformal-prediction sets** with a policy-declared target error rate, recorded in the evidence bundle so regulators see *calibrated uncertainty*, not a bare string. This directly fills Boruna's named "no uncertainty quantification" gap. (Quasar reports 42–56% faster execution and ~52% fewer approvals in its paper; treat numbers as unverified preprint claims.)
+
+### Theme D — Least-privilege capability tightening
+**Converging projects:** AILANG (Med), Mog (Med), Plumbing (Med), Lumen (Med).
+
+- **Capability-row inference** (AILANG): the typechecker computes each function's *minimal* capability set from its callees and flags any `!{...}` annotation that **over-declares** authority. Makes "this step's declared effects are exactly what it can reach" a derived, auditable fact.
+- **`optional` capabilities** (Mog): a step that degrades gracefully when a capability isn't granted, rather than hard-failing — useful for regulated "reduced-capability mode" runs, which Boruna's binary allow/deny Policy can't currently express.
+- **Static information-flow / data-visibility typing** (Plumbing): the strongest *new* guarantee here. Boruna gates *effects* (can this step call the network) but not *data visibility* (can step B observe the raw document step A read). Encoding "this step may not observe field X" in the typechecker gives a **data-minimisation / PII-partitioning** guarantee that regulators care about — a genuine extension of the compliance edge, not a re-skin. (The category-theoretic framing itself is not needed.)
+
+### Theme E — Agent-facing surface & structured, deterministic repair
+**Converging projects:** Codong (Med), X07 (Med), Zero (Low), Aver/Lume (Med), NERD (Med), Vow (Med-High), MoonBit (Med), B-IR (lesson).
+
+Boruna already has spans + suggested patches + a 10-tool MCP server. Cheap hardening the field has converged on:
+
+- **Structured error contract** (Codong): every diagnostic *and* every VM/capability-denial/worker error carries a stable `code` + `fix` + `retry` boolean, so an agent remediates without parsing prose. Especially valuable for the `boruna_check`/`boruna_repair` loop and distributed-runtime failures.
+- **Stable *versioned* diagnostic codes** (Zero, B-IR, Codong): codes contractually stable across compiler versions — agents match on the code, not the message. (Aligns with Boruna's existing `error_kind`/`protocol_version` convention — extend that discipline to all diagnostics.)
+- **Deterministic structural quickfixes** (X07): express repair patches as a **stable structural format (RFC 6902 JSON Patch)** the toolchain applies mechanically, so auto-repair is reproducible and *evidence-recordable* — a natural fit for Boruna's determinism story.
+- **Token-budgeted project-context MCP tool** (Aver's `aver context`, Lume's `kb pack`): a `boruna context --budget 10kb` MCP tool that packs types/effects/intents/diagnostics under a caller-set token cap, instead of dumping whole source/specs.
+- **`llms.txt` teaching corpus** (NERD): a single-fetch syntax+capability primer for coding agents. Near-zero cost.
+- **Self-generated, version-locked agent skill** (Vow): generate the coding-agent skill / `AGENTS.md` from the *same source* as the CLI, so guidance can't drift from behavior.
+- **Incremental typecheck over MCP** (MoonBit): expose a partial/incremental check endpoint an agent (or grammar-constrained decoder) can query mid-generation to reject ill-typed continuations — a reachable adaptation of MoonBit's famous token-sampler without owning model serving.
+
+### Theme F — Reproducibility & provenance, enforced not asserted
+**Converging projects:** Codex (Med), Tacit (Med), NanoLang (Med-High), Plasm (Med), Spec (Low).
+
+- **Reproducibility as a CI merge-gate** (Codex): require that recompiling an `.ax` module + re-running under replay yields **byte-identical bytecode and an identical evidence hash-chain**, failing the build otherwise. Turns "every run reproducible" from an ad-hoc-tested property into a continuously-enforced invariant.
+- **Content-addressed definition identity** (Tacit): hash at *definition* granularity (BLAKE3 of canonical text), not just per-package. Lets an evidence bundle pin the exact function bodies that executed and makes replay drift detectable at the symbol level.
+- **Mandatory inline self-tests** (NanoLang's `shadow` blocks): the compiler refuses to compile a function/step without a paired assertion block; results recorded in the hash chain → "every step shipped with a passing self-test." Boruna's `TestHarness` already exists to build on.
+- **Dry-run plan-then-execute-identical-artefact gate** (Plasm): compile a workflow to its execution DAG + declared-effect manifest, present *that* for review/approval, then execute the identical artefact. An explicit reviewable "here is exactly the effect plan I'm about to run," distinct from post-hoc evidence.
+
+### Theme G — Recovery & approval enrichment
+**Converging projects:** Pel (Med), Quasar (High, see Theme C/D), Plasm (Med).
+
+- **Condition/restart recovery model** (Pel, from Common Lisp restarts): a failed step surfaces a structured set of named, policy-gated resume options, chosen by a human approver or helper agent, each logged in the EventLog — resumable, typed recovery points as a richer alternative to binary approve/reject. Determinism preserved because the chosen restart is recorded.
+
+---
+
+## Full catalogue — per-project borrow ratings
+
+Ordered by borrow-value for Boruna. "Idea" = the one thing worth extracting (not necessarily the project's headline feature).
+
+| Project | Camp | Maturity (per catalogue) | Rating | Borrowable idea → Boruna subsystem |
+|---|---|---|---|---|
+| **Aver** | Verification | Rust, ★52, working | **High** | Graduated verify→adversarial→formal-proof ladder; token-budgeted `context` export → tooling + MCP |
+| **Intent** | Verification | Go→Rust/JS/WASM, working | **High** | `verified_by` prose↔contract no-drift binding (build fails on dangling ref) → typechecker + literate |
+| **Pact** | Verification | Rust, working | **High** | `intent` in signature → evidence bundle; declarative deterministic effect-swap in tests → syntax + replay |
+| **Quasar** | Orch.+Verif. | UPenn preprint, no impl | **High** | Conformal-prediction confidence sets on LLM effects; analysis-gated approvals → capability + evidence + gates |
+| **Vera** | Verification | Python→WASM, ★300+, working | **High** | LLM inference as tracked typed effect; three-tier contract discharge (Z3/guard/check) → typechecker + capability |
+| **NanoLang** | Verif.+Synt. | C, multi-target, working | **Med-High** | Mandatory inline `shadow` self-tests recorded in evidence → compiler + TestHarness + evidence |
+| **Vow** | Verification | Rust self-hosting, working | **Med-High** | Counterexample-as-replayable-evidence-artifact; self-generated version-locked toolchain skill → simulate + MCP |
+| **AILANG** | Verification | Go, Apache-2.0, working | Medium | Capability-row inference (flag over-declared authority) → typechecker + capability |
+| **Codex** | Verif.+Orch. | self-hosting, working | Medium | Byte-identical reproducibility as CI merge-gate → CI + evidence |
+| **Codong** | Syntactic | Go, ★68, working | Medium | `code`/`fix`/`retry` structured error schema → diagnostics + MCP |
+| **Fabro** | Orchestration | Rust, working | Medium | CSS-like selector+specificity overlay to assign model/effort/policy to nodes → orchestrator/DAG |
+| **LLMLang** | Synt.+Verif. | Rust→LLVM+OpenCL, working | Medium | Marker-triggered compiler-injected instrumentation (OTel spans) → codegen + EventLog |
+| **Lume** | Syntactic | Go transpiler, early | Medium | Token-budgeted KB retrieval (`kb pack --max-tokens`) as MCP tool → MCP + tooling |
+| **Lumen** | Orchestration | Rust→bytecode VM+WASM, working | Medium | Parameterized capability grants w/ numeric caps (max_tokens, temp) → capability + evidence |
+| **Marsha** | Orchestration | Python, abandoned 2023 | Medium | Examples→generated test suite→bounded corrective-repair loop → trace2tests + repair |
+| **Mog** | Synt.+Verif. | Rust→QBE, working (embedded) | Medium | `optional` capabilities / graceful degradation; host capability manifest → CapabilityGateway + Policy |
+| **MoonBit** | Verification | OCaml, ★2115+, most mature | Medium | Incremental/partial typecheck over MCP for constrained generation → compiler + MCP |
+| **NERD** | Syntactic | C→LLVM, ★135, working | Medium | `llms.txt` teaching corpus; first-class capability-gated `llm`/`mcp` primitives → MCP + syntax |
+| **Pel** | Orchestration | CMU preprint, no impl | Medium | Condition/restart typed recovery model for approval gates → distributed runtime + gates |
+| **Plasm** | Orch.+Synt. | Rust, BSL-1.1, working | Medium | Dry-run plan-then-execute-identical-artefact gate → CLI + approval gate |
+| **Plumbing** | Substrate | preprint, native, undisclosed | Medium | Static information-flow / data-visibility typing between steps (PII partitioning) → typechecker + PolicySet |
+| **Prove** | Verification | Python→C, working | Medium | Verified `explain` blocks (CNL checked vs contracts) → literate + typechecker |
+| **Tacit** | Synt.+Verif. | Rust→LLVM, working | Medium | Content-addressed definition-level hashing; typed `Hole` nodes → evidence + package + repair |
+| **X07** | Syntactic | Rust→C+WASM, working | Medium | JSON-Patch deterministic quickfixes; versioned machine-facing portal → repair + MCP |
+| **Axis** | Synt.+Verif. | Rust, ★3, working | Low | Grammar-as-state-machine for constrained decoding — off-thesis (Boruna is post-hoc) |
+| **Magpie** | Syntactic | Rust→LLVM, early | Low | SSA-as-surface — philosophically opposite to readable-surface+separate-IR |
+| **Spec** | Orch./unclass. | TS/React POC, proposal | Low | Role-owned typed artefacts w/ handoff ordering (provenance framing only) → orchestrator + evidence |
+| **Zero** | Verif.+Synt. | C bootstrap, early (Vercel Labs) | Low | Stable versioned diagnostic codes (rest convergent) → diagnostics |
+| **B-IR** | Syntactic | Python→Arm64, thought experiment | None | *Lesson:* don't token-golf; keep stable matchable error codes + pre/postconditions |
+| **BHC/hx** | Verif.+Orch. | Rust wrapper, early | None | Thesis-agreement (purity/determinism) but no transferable mechanism |
+| **Koru** | unclassified | Zig superset, pre-alpha | None | Mandatory event-branch exhaustiveness — already covered by Boruna's `match`/`UpdateResult` |
+| **Laze** | Syntactic | Python→C, weekend experiment | None | Strip-surface-for-generation-speed — antithetical to auditability |
+| **Sever** | Syntactic | Zig, self-disclaimed art | None | Single-char opcode density — unverified, conflicts with readability |
+| **Valea** | unclassified | Rust MVP, "noise floor" marker | None | Nothing shipped Boruna doesn't already have |
+
+Distribution: **High 5 · Med-High 2 · Medium 17 · Low 4 · None 6.**
+
+---
+
+## Recommended next steps (for human decision — not executed)
+
+1. **Refresh the catalogue listing** — Boruna is shown at v0.2.0/★0; the real project is v1.5.0 with distributed execution, REPL, literate workflows, ITF export, and `simulate`. A quick PR/message to the catalogue maintainer (Negroni Venture Studios) corrects a materially stale entry.
+2. **Pick the moat-deepening cluster first (Themes A+B+C).** They close both named gaps *and* reuse existing subsystems (`simulate`/witness DSL, typechecker, capability system, evidence bundles, literate workflows). Suggested spike order:
+   - **B first** (cheapest, highest thesis-fit): `intent` in signatures → evidence; `verified_by`/`explain` prose↔contract binding checked by the compiler.
+   - **A next**: optional `requires`/`ensures`, with `simulate` as the sampled tier and a runtime guard that logs a replayable counterexample to the EventLog; feature-flag Z3 for the decidable tier later.
+   - **C alongside**: `llm` as a propagated typed effect + conformal-prediction confidence in evidence.
+3. **Batch the tactical hardening (Theme E)** into one DX sprint — structured `code/fix/retry` diagnostics, versioned codes, JSON-Patch quickfixes, `boruna context` MCP tool, `llms.txt`, auto-generated version-locked agent skill. All small, all reinforce the agent-authoring loop.
+4. **Consider Theme F's reproducibility merge-gate** as a CI addition — it enforces Boruna's loudest claim continuously and is cheap given the evidence machinery already exists.
+5. **Explicitly decide NOT to** token-optimize `.ax` syntax, adopt JSON-AST-as-source, or add mandatory (vs optional) contracts. The catalogue's own evidence argues against the first two; the third doesn't fit a workflow-step model.
+
+> Per `/sc:research` boundaries: this report stops at findings + recommendations. Use `/sc:design` to turn any theme into an architecture, or `/sc:implement` to build a spike.
+
+---
+
+## Sources
+
+- agentlanguages.dev catalogue (index) — https://agentlanguages.dev/#catalogue
+- Boruna analysis page — https://agentlanguages.dev/languages/boruna/
+- Per-project analysis pages — https://agentlanguages.dev/languages/{ailang,aver,axis,b-ir,bhc-hx,codex,codong,fabro,intent,koru,laze,llmlang,lume,lumen,magpie,marsha,mog,moonbit,nanolang,nerd,pact,pel,plasm,plumbing,prove,quasar,sever,spec,tacit,valea,vera,vow,x07,zero}/
+- Framing essay: "Three camps alike in dignity" — Negroni Venture Studios blog, 2026-05-20
+- Boruna internal profile: repo `CLAUDE.md`, Serena memories (architecture, project-conventions-2026-04, release-1.5.0-status)
+
+*Primary evidence throughout is the catalogue's own per-project analysis (opinionated but well-sourced). Maturity/benchmark figures for preprint and single-author projects are unverified and flagged as such.*

--- a/crates/llmbc/src/module.rs
+++ b/crates/llmbc/src/module.rs
@@ -56,6 +56,12 @@ pub struct Function {
     pub code: Vec<Op>,
     /// Capabilities this function is allowed to use.
     pub capabilities: Vec<Capability>,
+    /// Machine-read declared purpose (from the source `intent "..."` clause),
+    /// surfaced in evidence bundles. Replay-verified: it is part of what was
+    /// authorized, so changing it changes the step's evidence identity.
+    /// `#[serde(default)]` keeps pre-Sprint-1 modules loading with `None`.
+    #[serde(default)]
+    pub intent: Option<String>,
     /// Match tables referenced by Match instructions.
     pub match_tables: Vec<Vec<MatchArm>>,
 }

--- a/crates/llmbc/src/tests.rs
+++ b/crates/llmbc/src/tests.rs
@@ -62,6 +62,7 @@ mod tests {
             locals: 1,
             code: vec![Op::PushConst(0), Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
 
@@ -81,6 +82,7 @@ mod tests {
             locals: 0,
             code: vec![Op::PushConst(0), Op::PushConst(1), Op::Halt],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
 
@@ -88,6 +90,54 @@ mod tests {
         assert_eq!(&bytes[0..4], &MAGIC);
         let restored = Module::from_bytes(&bytes).unwrap();
         assert_eq!(module, restored);
+    }
+
+    #[test]
+    fn test_module_intent_json_roundtrip() {
+        let mut module = Module::new("test");
+        module.add_function(Function {
+            name: "main".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Ret],
+            capabilities: vec![],
+            intent: Some("Declared purpose of this step".into()),
+            match_tables: vec![],
+        });
+        let json = module.to_json().unwrap();
+        let restored = Module::from_json(&json).unwrap();
+        assert_eq!(module, restored);
+        assert_eq!(
+            restored.functions[0].intent.as_deref(),
+            Some("Declared purpose of this step")
+        );
+    }
+
+    #[test]
+    fn test_module_legacy_json_without_intent_defaults_to_none() {
+        // A module serialized before Sprint 1 has no `intent` key on its
+        // functions. `#[serde(default)]` must load it cleanly as `None`.
+        let mut module = Module::new("test");
+        module.add_function(Function {
+            name: "main".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Ret],
+            capabilities: vec![],
+            intent: None,
+            match_tables: vec![],
+        });
+        let json = module.to_json().unwrap();
+        // Strip the `intent` key from every function object to simulate a
+        // pre-Sprint-1 serialized module.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for func in value["functions"].as_array_mut().unwrap() {
+            func.as_object_mut().unwrap().remove("intent");
+        }
+        let legacy_json = serde_json::to_string(&value).unwrap();
+        assert!(!legacy_json.contains("intent"));
+        let restored = Module::from_json(&legacy_json).unwrap();
+        assert_eq!(restored.functions[0].intent, None);
     }
 
     #[test]

--- a/crates/llmc/src/ast.rs
+++ b/crates/llmc/src/ast.rs
@@ -30,6 +30,10 @@ pub struct FnDef {
     pub params: Vec<Param>,
     pub return_type: Option<TypeExpr>,
     pub capabilities: Vec<String>,
+    /// Machine-read declared purpose (`intent "..."`), captured into the
+    /// evidence bundle so an auditor sees what a step was *meant* to do.
+    #[serde(default)]
+    pub intent: Option<String>,
     pub requires: Vec<Expr>,
     pub ensures: Vec<Expr>,
     pub body: Block,

--- a/crates/llmc/src/codegen.rs
+++ b/crates/llmc/src/codegen.rs
@@ -127,6 +127,7 @@ impl Emitter {
             locals: fe.next_local as u16,
             code: fe.code,
             capabilities: fe.capabilities,
+            intent: f.intent.clone(),
             match_tables: fe.match_tables,
         };
         self.module.add_function(func);

--- a/crates/llmc/src/lexer.rs
+++ b/crates/llmc/src/lexer.rs
@@ -64,6 +64,8 @@ pub enum TokenKind {
     Requires,
     #[token("ensures")]
     Ensures,
+    #[token("intent")]
+    Intent,
     #[token("spawn")]
     Spawn,
     #[token("send")]

--- a/crates/llmc/src/parser.rs
+++ b/crates/llmc/src/parser.rs
@@ -31,6 +31,7 @@ fn display_token(kind: &TokenKind) -> String {
         TokenKind::ErrKw => "'Err'".into(),
         TokenKind::Requires => "'requires'".into(),
         TokenKind::Ensures => "'ensures'".into(),
+        TokenKind::Intent => "'intent'".into(),
         TokenKind::Spawn => "'spawn'".into(),
         TokenKind::Send => "'send'".into(),
         TokenKind::Receive => "'receive'".into(),
@@ -104,6 +105,7 @@ fn keyword_spelling(kind: &TokenKind) -> Option<&'static str> {
         TokenKind::ErrKw => "Err",
         TokenKind::Requires => "requires",
         TokenKind::Ensures => "ensures",
+        TokenKind::Intent => "intent",
         TokenKind::Spawn => "spawn",
         TokenKind::Send => "send",
         TokenKind::Receive => "receive",
@@ -206,6 +208,24 @@ impl Parser {
             }
             other => Err(self.error(format!(
                 "expected identifier, found {}",
+                display_token(other)
+            ))),
+        }
+    }
+
+    fn expect_string(&mut self) -> Result<String, CompileError> {
+        self.skip_newlines();
+        if self.pos >= self.tokens.len() {
+            return Err(self.error("expected string literal, found end of input".into()));
+        }
+        match &self.tokens[self.pos].kind {
+            TokenKind::StringLit(s) => {
+                let s = s.clone();
+                self.pos += 1;
+                Ok(s)
+            }
+            other => Err(self.error(format!(
+                "expected string literal, found {}",
                 display_token(other)
             ))),
         }
@@ -336,16 +356,28 @@ impl Parser {
             Vec::new()
         };
 
-        // Parse requires/ensures
+        // Parse intent / requires / ensures clauses (order-independent).
+        let mut intent: Option<String> = None;
         let mut requires = Vec::new();
         let mut ensures = Vec::new();
-        while self.check(&TokenKind::Requires) || self.check(&TokenKind::Ensures) {
-            if self.check(&TokenKind::Requires) {
+        loop {
+            if self.check(&TokenKind::Intent) {
+                self.advance();
+                if intent.is_some() {
+                    return Err(self.error(
+                        "duplicate 'intent' clause: a function may declare at most one intent"
+                            .into(),
+                    ));
+                }
+                intent = Some(self.expect_string()?);
+            } else if self.check(&TokenKind::Requires) {
                 self.advance();
                 requires.push(self.parse_expr()?);
-            } else {
+            } else if self.check(&TokenKind::Ensures) {
                 self.advance();
                 ensures.push(self.parse_expr()?);
+            } else {
+                break;
             }
         }
 
@@ -356,6 +388,7 @@ impl Parser {
             params,
             return_type,
             capabilities,
+            intent,
             requires,
             ensures,
             body,

--- a/crates/llmc/src/suggest.rs
+++ b/crates/llmc/src/suggest.rs
@@ -14,8 +14,8 @@ use strsim::levenshtein;
 /// canonical spelling here.
 pub const KEYWORDS: &[&str] = &[
     "fn", "let", "mut", "if", "else", "match", "return", "type", "enum", "module", "import",
-    "export", "true", "false", "None", "Some", "Ok", "Err", "requires", "ensures", "spawn", "send",
-    "receive", "emit", "while", "for", "in",
+    "export", "true", "false", "None", "Some", "Ok", "Err", "requires", "ensures", "intent",
+    "spawn", "send", "receive", "emit", "while", "for", "in",
 ];
 
 /// Returns the unique keyword within Levenshtein distance ≤ 1 of

--- a/crates/llmc/src/tests.rs
+++ b/crates/llmc/src/tests.rs
@@ -140,6 +140,67 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_intent() {
+        let tokens = lexer::lex(r#"fn main() -> Int intent "Compute the answer" { 42 }"#).unwrap();
+        let program = parser::parse(tokens).unwrap();
+        if let Item::Function(f) = &program.items[0] {
+            assert_eq!(f.intent.as_deref(), Some("Compute the answer"));
+        } else {
+            panic!("expected function");
+        }
+    }
+
+    #[test]
+    fn test_parse_no_intent_is_none() {
+        let tokens = lexer::lex("fn main() -> Int { 42 }").unwrap();
+        let program = parser::parse(tokens).unwrap();
+        if let Item::Function(f) = &program.items[0] {
+            assert_eq!(f.intent, None);
+        } else {
+            panic!("expected function");
+        }
+    }
+
+    #[test]
+    fn test_parse_duplicate_intent_errors() {
+        let tokens = lexer::lex(r#"fn main() -> Int intent "a" intent "b" { 0 }"#).unwrap();
+        let err = parser::parse(tokens).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("duplicate 'intent'"),
+            "expected duplicate-intent error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_intent_with_capabilities_and_requires() {
+        // intent coexists with capability annotations and requires clauses,
+        // in any order after the signature.
+        let tokens = lexer::lex(
+            r#"fn transfer(x: Int) -> Int !{db.write} intent "Move funds" requires x { x }"#,
+        )
+        .unwrap();
+        let program = parser::parse(tokens).unwrap();
+        if let Item::Function(f) = &program.items[0] {
+            assert_eq!(f.capabilities, vec!["db.write"]);
+            assert_eq!(f.intent.as_deref(), Some("Move funds"));
+            assert_eq!(f.requires.len(), 1);
+        } else {
+            panic!("expected function");
+        }
+    }
+
+    #[test]
+    fn test_codegen_threads_intent_to_function() {
+        let module = compile("m", r#"fn main() -> Int intent "declared purpose" { 7 }"#).unwrap();
+        let main = module
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("main function present");
+        assert_eq!(main.intent.as_deref(), Some("declared purpose"));
+    }
+
+    #[test]
     fn test_parse_type_def() {
         let tokens = lexer::lex("type User { name: String, age: Int }").unwrap();
         let program = parser::parse(tokens).unwrap();

--- a/crates/llmfw/src/runtime.rs
+++ b/crates/llmfw/src/runtime.rs
@@ -267,6 +267,7 @@ impl AppRuntime {
                 locals: 0,
                 code: wrapper_code,
                 capabilities: Vec::new(),
+                intent: None,
                 match_tables: Vec::new(),
             };
             let wrapper_idx = wrapper.add_function(wrapper_fn);

--- a/crates/llmfw/src/tests.rs
+++ b/crates/llmfw/src/tests.rs
@@ -945,6 +945,7 @@ fn view(state: State) -> UINode {
                 Op::Ret,
             ],
             capabilities: Vec::new(),
+            intent: None,
             match_tables: Vec::new(),
         };
 
@@ -965,6 +966,7 @@ fn view(state: State) -> UINode {
                 Op::Ret,
             ],
             capabilities: vec![Capability::TimeNow], // Function declares cap
+            intent: None,
             match_tables: Vec::new(),
         };
 
@@ -980,6 +982,7 @@ fn view(state: State) -> UINode {
                 Op::Ret,
             ],
             capabilities: Vec::new(),
+            intent: None,
             match_tables: Vec::new(),
         };
 
@@ -1014,6 +1017,7 @@ fn view(state: State) -> UINode {
             locals: 0,
             code: vec![Op::PushConst(0), Op::MakeRecord(0, 1), Op::Ret],
             capabilities: Vec::new(),
+            intent: None,
             match_tables: Vec::new(),
         };
 
@@ -1029,6 +1033,7 @@ fn view(state: State) -> UINode {
                 Op::Ret,
             ],
             capabilities: Vec::new(),
+            intent: None,
             match_tables: Vec::new(),
         };
 
@@ -1039,6 +1044,7 @@ fn view(state: State) -> UINode {
             locals: 1,
             code: vec![Op::CapCall(Capability::TimeNow.id(), 0), Op::Ret],
             capabilities: vec![Capability::TimeNow],
+            intent: None,
             match_tables: Vec::new(),
         };
 

--- a/crates/llmvm-cli/src/dashboard.rs
+++ b/crates/llmvm-cli/src/dashboard.rs
@@ -491,7 +491,7 @@ fn render_detail(
         html_escape(&run.run_id)
     ));
 
-    wrap_page(&format!("Run {}", &run.run_id), &banner, &body)
+    wrap_page(&format!("Run {}", run.run_id), &banner, &body)
 }
 
 /// Render a single step's Output cell. Sprint 0.5-S7b.

--- a/crates/llmvm/src/tests.rs
+++ b/crates/llmvm/src/tests.rs
@@ -20,6 +20,7 @@ mod tests {
                 Capability::NetFetch,
                 Capability::FsRead,
             ],
+            intent: None,
             match_tables: vec![],
         });
         module
@@ -172,6 +173,7 @@ mod tests {
             locals: 0,
             code: vec![Op::PushConst(0), Op::PushConst(1), Op::Call(1, 2), Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
 
@@ -182,6 +184,7 @@ mod tests {
             locals: 2,
             code: vec![Op::LoadLocal(0), Op::LoadLocal(1), Op::Add, Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
 
@@ -1189,6 +1192,7 @@ mod tests {
             locals: 0,
             code: vec![Op::PushConst(0), Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::Int(0));
@@ -1208,6 +1212,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 1; // main is at index 1
@@ -1233,6 +1238,7 @@ mod tests {
             locals: 0,
             code: vec![Op::PushConst(0), Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::Int(0));
@@ -1245,6 +1251,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 1; // main is at index 1
@@ -1405,6 +1412,7 @@ mod tests {
             locals: 0,
             code: vec![Op::PushConst(0), Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::Int(99));
@@ -1420,6 +1428,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::Int(42));
@@ -1447,6 +1456,7 @@ mod tests {
                 Op::Ret,        // return payload
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         // Function 1: main — spawns worker, sends Int(77), returns 0
@@ -1464,6 +1474,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::Int(77));
@@ -1494,6 +1505,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::ActorId(0));
@@ -1511,6 +1523,7 @@ mod tests {
                 Op::Ret,           // return received payload
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 1;
@@ -1533,6 +1546,7 @@ mod tests {
             locals: 0,
             code: vec![Op::ReceiveMsg, Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         // Function 1: main — spawns worker, then blocks on receive
@@ -1542,6 +1556,7 @@ mod tests {
             locals: 0,
             code: vec![Op::SpawnActor(0), Op::Pop, Op::ReceiveMsg, Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 1;
@@ -1574,6 +1589,7 @@ mod tests {
                 Op::Jmp(0),       // 4: loop back
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::ActorId(0));
@@ -1596,6 +1612,7 @@ mod tests {
                 Op::Jmp(5),        // 9: loop back to receive
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 1;
@@ -1658,6 +1675,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         // Function 1: worker_b — sends Int(2) to parent
@@ -1673,6 +1691,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::ActorId(0)); // 0: parent id
@@ -1700,6 +1719,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 2;
@@ -1825,6 +1845,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::ActorId(0));
@@ -1837,6 +1858,7 @@ mod tests {
             locals: 0,
             code: vec![Op::SpawnActor(0), Op::Pop, Op::ReceiveMsg, Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 1;
@@ -1882,6 +1904,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::Int(1));
@@ -1898,6 +1921,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 1;
@@ -1932,6 +1956,7 @@ mod tests {
             locals: 0,
             code: vec![Op::ReceiveMsg, Op::Ret],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         // Function 1: child — spawns grandchild, then crashes (div by zero)
@@ -1948,6 +1973,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.constants.push(Value::Int(1));
@@ -1964,6 +1990,7 @@ mod tests {
                 Op::Ret,
             ],
             capabilities: vec![],
+            intent: None,
             match_tables: vec![],
         });
         module.entry = 2;

--- a/docs/design-intent-evidence.md
+++ b/docs/design-intent-evidence.md
@@ -1,0 +1,71 @@
+# Design — Intent annotations → evidence bundles (Theme B, Sprint 1)
+
+**Program context:** First of a sequenced multi-sprint program borrowing the 5 High-rated ideas from the agentlanguages.dev competitive research (`claudedocs/research_agentlanguages_competitive_2026-07-15.md`). Order: **B → A → C → D**, each its own minor release.
+
+- **Sprint 1 (this doc):** Theme B — machine-read `intent` per function/step, captured into the evidence bundle; prose↔fact binding in literate workflows.
+- Borrowed from: **Pact** (`intent` in signature → audit record), **Intent** (`verified_by` no-drift binding), **Prove** (verified `explain` blocks), **Aver** (`?` prose intent).
+
+## Forcing questions (Think)
+
+- **Who needs this?** Regulators/auditors reading a Boruna evidence bundle. Today they see *what ran* (inputs, outputs, model responses, approvals, hashes) but not *what each step was supposed to do* — they must cross-reference external design docs.
+- **Narrowest MVP someone would pay for?** An `intent "..."` clause on an `.ax` function that is captured verbatim into the hash-chained evidence bundle for every executed step. "Declared purpose" sits next to "actual behaviour," both tamper-evident.
+- **What makes someone say "whoa"?** The prose can't lie: a literate-workflow narrative that references a step's declared intent/capabilities is **compiler-verified** — a dangling or drifted reference fails the build. Documentation that is mechanically bound to the code it describes.
+- **How does it compound?** Every later theme (contracts, typed LLM effects, capability inference) produces machine facts that intent/explain prose can cite via the same no-drift binding — the audit narrative grows richer without ever drifting.
+
+## Scope
+
+**In (Sprint 1):**
+1. `intent "<string>"` clause on `fn` definitions (`.ax` syntax).
+2. Thread intent through: lexer → AST → parser → codegen → bytecode `Function` (additive, serde-default; old modules load with `intent: None`).
+3. Surface intent in `boruna ast` (automatic via serde) and `boruna compile` module info.
+4. Capture the entry function's intent into the evidence bundle step record.
+5. Tests: parse, serialize roundtrip, evidence capture, backward-compat load.
+
+**Deferred to a Sprint 1b slice (still Theme B):**
+- `verified_by` / `explain` prose↔fact binding in literate workflows (larger literate-tooling change; lands after the core `intent` primitive ships).
+
+**Out (later themes):** contracts/SMT (A), typed LLM effects/uncertainty (C), capability inference/info-flow (D). Note: `FnDef` already carries `requires`/`ensures` Vec<Expr> fields (unused today) — Theme A will build on those; this sprint does not touch them.
+
+## Data flow
+
+```
+fn transfer(x: Int) -> Int !{db.write} intent "Move funds between accounts"
+        │
+   lexer: TokenKind::Intent + StringLit
+        │
+   parser::parse_fn_def → FnDef { intent: Some("Move funds…"), .. }
+        │
+   codegen → bytecode Function { intent: Some(...), capabilities, .. }  (serde, #[serde(default)])
+        │
+   orchestrator step run → read entry fn intent → evidence bundle step record
+        │
+   evidence verify / inspect → intent shown, inside the hash chain
+```
+
+## Design decisions
+
+- **`intent` is `Option<String>`, optional.** Unlike Pact/Vera (mandatory), Boruna steps don't all need prose; forcing it would be gold-plating and break existing `.ax`.
+- **Grammar position:** after capability annotations, before `requires`/`ensures`. One `intent` per fn (a second is a parse error — keeps it a single declarative purpose, matching Pact).
+- **Additive bytecode.** `Function.intent` gets `#[serde(default)]`. Determinism note (§15): intent is **replay-verified** input to the evidence hash (it's declared source, part of "what was authorized"), NOT operational-only — changing a step's intent changes its evidence identity, which is correct.
+- **No new dep.** Pure additive language/serialization change.
+
+## Acceptance criteria
+
+- `fn f() -> Int intent "does a thing" { 0 }` parses; `intent` visible in `boruna ast --json`.
+- A module compiled without `intent` loads unchanged; a pre-Sprint-1 serialized module deserializes with `intent: None`.
+- Two `intent` clauses on one fn → parse error with a clear message.
+- An executed workflow step's evidence record contains the declared intent; `evidence verify` still PASSES (hash chain intact) and `evidence inspect` shows it.
+- Gates green: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`.
+
+## Test plan
+
+| Case | Layer | Assert |
+|---|---|---|
+| parse single intent | parser | `FnDef.intent == Some("...")` |
+| parse no intent | parser | `FnDef.intent == None` |
+| double intent | parser | `Err` with message naming duplicate intent |
+| intent + capabilities + requires order | parser | all three parsed |
+| codegen threads intent | codegen | `Function.intent == Some("...")` |
+| serialize roundtrip | bytecode | intent survives serde round-trip |
+| legacy module load | bytecode | JSON without `intent` key → `None` |
+| evidence capture | orchestrator | step record carries intent; bundle verifies |

--- a/docs/reference/ax-language.md
+++ b/docs/reference/ax-language.md
@@ -73,6 +73,24 @@ fn fetch_and_cache(url: String) -> String !{net.fetch, fs.write} {
 
 Without the annotation, the VM will reject any attempt to call the capability at runtime.
 
+## Intent declarations
+
+A function may declare a single machine-read purpose with an `intent "..."` clause
+after its signature. The clause is optional and order-independent with capability
+and contract clauses:
+
+```ax
+fn transfer(amount: Int) -> Int !{db.write} intent "Move funds between accounts" {
+    // implementation
+}
+```
+
+Intent is captured into the run's evidence bundle (`intents.json`, keyed by step id)
+so an auditor sees what each step was *authorized* to do alongside what it actually
+did. It is covered by the bundle checksums, so tampering with a captured intent makes
+`boruna evidence verify` fail. A function may declare at most one `intent`; a second
+is a compile error.
+
 ## Records
 
 Define named record types:

--- a/orchestrator/src/audit/evidence.rs
+++ b/orchestrator/src/audit/evidence.rs
@@ -145,6 +145,26 @@ impl EvidenceBundleBuilder {
         self.write_file(name, content)
     }
 
+    /// Store per-step declared intents (`intent "..."` clauses) as
+    /// `intents.json`, mapping step_id → declared purpose. Only steps
+    /// that declared an intent appear. Written via `write_file`, so the
+    /// component is checksummed, covered by `bundle_hash`, and checked by
+    /// `evidence verify` like every other component. Intent is
+    /// replay-verified evidence: it records what each step was *authorized*
+    /// to do, alongside the outputs recording what it actually did.
+    /// No-op when the map is empty (no `intents.json` is written).
+    pub fn add_intents(
+        &mut self,
+        intents: &std::collections::BTreeMap<String, String>,
+    ) -> std::io::Result<()> {
+        if intents.is_empty() {
+            return Ok(());
+        }
+        // BTreeMap serializes with sorted keys → deterministic bytes.
+        let json = serde_json::to_string_pretty(intents).map_err(std::io::Error::other)?;
+        self.write_file("intents.json", &json)
+    }
+
     /// Finalize the bundle: write audit log, env fingerprint, and manifest.
     pub fn finalize(mut self, audit_log: &AuditLog) -> std::io::Result<BundleManifest> {
         let completed_at = chrono::Utc::now().to_rfc3339();
@@ -217,6 +237,9 @@ impl EvidenceBundleBuilder {
         }
         if self.bundle_dir.join("outputs").exists() {
             components.push("outputs/".to_string());
+        }
+        if self.bundle_dir.join("intents.json").exists() {
+            components.push("intents.json".to_string());
         }
         components.sort();
 
@@ -355,6 +378,73 @@ mod tests {
         assert!(bundle_path.join("audit_log.json").exists());
         assert!(bundle_path.join("env_fingerprint.json").exists());
         assert!(bundle_path.join("outputs/step1/result.json").exists());
+    }
+
+    #[test]
+    fn test_bundle_captures_intents_and_is_tamper_evident() {
+        use crate::audit::verify::verify_bundle;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut builder =
+            EvidenceBundleBuilder::new(dir.path(), "run-intent-001", "intent-wf").unwrap();
+        builder.add_workflow_def(r#"{"name":"test"}"#).unwrap();
+        builder.add_policy(r#"{"default_allow":true}"#).unwrap();
+
+        let mut intents = std::collections::BTreeMap::new();
+        intents.insert(
+            "step1".to_string(),
+            "Move funds between accounts".to_string(),
+        );
+        builder.add_intents(&intents).unwrap();
+
+        let mut audit = AuditLog::new();
+        audit.append(AuditEvent::WorkflowStarted {
+            workflow_hash: "abc".into(),
+            policy_hash: "def".into(),
+        });
+        audit.append(AuditEvent::WorkflowCompleted {
+            result_hash: "res".into(),
+            total_duration_ms: 10,
+        });
+        let manifest = builder.finalize(&audit).unwrap();
+
+        let bundle_path = dir.path().join("run-intent-001");
+        // intents.json written and covered by the manifest checksums.
+        assert!(bundle_path.join("intents.json").exists());
+        assert!(manifest.file_checksums.contains_key("intents.json"));
+
+        // A pristine bundle verifies.
+        let ok = verify_bundle(&bundle_path);
+        assert!(ok.valid, "expected valid bundle, errors: {:?}", ok.errors);
+
+        // Tampering the captured intent breaks verification — intent is
+        // inside the hash chain, not decorative.
+        std::fs::write(
+            bundle_path.join("intents.json"),
+            r#"{"step1":"tampered purpose"}"#,
+        )
+        .unwrap();
+        let bad = verify_bundle(&bundle_path);
+        assert!(!bad.valid, "tampered intents.json must fail verification");
+    }
+
+    #[test]
+    fn test_bundle_no_intents_writes_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut builder =
+            EvidenceBundleBuilder::new(dir.path(), "run-intent-002", "intent-wf").unwrap();
+        builder.add_workflow_def(r#"{"name":"test"}"#).unwrap();
+        // Empty intent map → no intents.json component.
+        builder
+            .add_intents(&std::collections::BTreeMap::new())
+            .unwrap();
+        let audit = AuditLog::new();
+        builder.finalize(&audit).unwrap();
+        assert!(!dir
+            .path()
+            .join("run-intent-002")
+            .join("intents.json")
+            .exists());
     }
 
     #[test]

--- a/orchestrator/src/workflow/runner.rs
+++ b/orchestrator/src/workflow/runner.rs
@@ -4589,6 +4589,32 @@ pub fn create_bundle(
         }
     }
 
+    // Per-step declared intents (Theme B): extract each source-kind step's
+    // `intent "..."` clause and record it in the bundle so an auditor sees
+    // what each step was *authorized* to do next to what it did. The intent
+    // is already transitively covered by `workflow_hash` (source is hashed);
+    // `intents.json` surfaces it without forcing a recompile. Compilation
+    // here is deterministic and every source already compiled during
+    // execution, so a compile error (should not occur) or a step with no
+    // intent simply contributes nothing rather than failing the bundle —
+    // intent is additive audit metadata, never load-bearing for the run.
+    let mut intents: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+    for (step_id, source) in &metadata.step_sources {
+        if let Ok(module) = boruna_compiler::compile(step_id, source) {
+            if let Some(intent) = module
+                .functions
+                .iter()
+                .find(|f| f.name == "main")
+                .and_then(|f| f.intent.clone())
+            {
+                intents.insert(step_id.clone(), intent);
+            }
+        }
+    }
+    builder
+        .add_intents(&intents)
+        .map_err(|e| WorkflowRunError::Io(format!("bundle add_intents: {e}")))?;
+
     // Hash-chained audit log from metadata. We verify the chain at
     // bundle-creation time so that direct sqlite3 tamper of
     // `metadata.audit_log` surfaces *here* (operator gets a clear


### PR DESCRIPTION
## Theme B / Sprint 1 — agentlanguages.dev competitive-borrow program

Borrowed from **Pact** (intent-in-signature → audit record) and **Intent**/**Prove** (machine-read purpose). See `claudedocs/research_agentlanguages_competitive_2026-07-15.md` and `docs/design-intent-evidence.md`.

### What
- New optional `intent "..."` clause on `fn` definitions (order-independent with capability/`requires`/`ensures`; duplicate → parse error).
- Threads lexer → AST (`FnDef.intent`) → codegen → bytecode (`Function.intent`, additive `#[serde(default)]` — pre-1.6 modules load with `None`).
- Surfaced in `boruna ast --json`.
- Each source-kind step's intent captured into the evidence bundle as `intents.json`, covered by bundle checksums + `bundle_hash` → `evidence verify` fails on tamper.

### Determinism (§15)
Intent is replay-verified evidence (already transitively in `workflow_hash`); `intents.json` surfaces it for auditors without a recompile.

### Gates (local)
compiler ✓ · bytecode ✓ · orchestrator 447 ✓ · framework 96 ✓ · vm ✓ · clippy `--all-targets --features serve` ✓ · fmt ✓. (`coord_register_rejects_binary_mismatch` flaked once under heavy parallel load; passes isolated — unrelated network-port integration test.)

### Release
Bumps 1.5.0 → 1.6.0 (CHANGELOG, README badge). Tag `v1.6.0` after merge.