### PR TITLE
feat(contracts): runtime-checked requires preconditions + counterexample evidence (v1.7.0, Theme A-lite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.7.0] — 2026-07-15
+
+Seventh feature minor on the 1.x LTS line. Second sprint of the agentlanguages.dev
+competitive-borrow program (Theme A-lite): runtime-checked contracts with
+concrete, replayable counterexamples — no SMT.
+
+### Added
+
+- **Runtime-checked `requires` preconditions with counterexample evidence.** Sprint 2 / Theme A-lite of the agentlanguages.dev competitive-borrow program — borrowed from **Vera**/**Aver** (design-by-contract) and **Vow** (counterexample = concrete replayable input). A function's `requires <expr>` clauses are now compiled to runtime guards checked at entry against the arguments; a violation traps with a new `VmError::ContractViolation { message, counterexample }` where `counterexample` is the offending argument list (positional, rendered) — the exact input an auditor needs to reproduce the breach. The failure surfaces with a stable, distinct `error_kind` `contract_violation` (retry: no — a violation is a deterministic function of the inputs), and because failed-step errors are recorded in the hash-chained audit log, the counterexample lands in tamper-evident evidence. Reuses the previously-dormant `Op::Assert` opcode (no bytecode bump); functions without contracts emit no guard. **Deliberately NO SMT/Z3** — this stays in Boruna's concrete-trace + replay philosophy, consistent with the 1.5.0 "Decided" ruling against symbolic model checking. `ensures` postconditions (needing a `result` binding at each return) are a documented follow-up. See `docs/design-contracts-runtime.md`.
+
 ## [1.6.0] — 2026-07-15
 
 Sixth feature minor on the 1.x LTS line. First sprint of the agentlanguages.dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "boruna-benches"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-bytecode"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "axum",
  "boruna-bytecode",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-compiler"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-vm",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-effect"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "serde",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-framework"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-lsp"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-compiler",
  "boruna-tooling",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-mcp"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-orchestrator"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-pkg"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-tooling"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-vm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "boruna-bytecode",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/escapeboy/boruna/actions/workflows/ci.yml/badge.svg)](https://github.com/escapeboy/boruna/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.6.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.7.0-blue.svg)](CHANGELOG.md)
 [![Status: Stable](https://img.shields.io/badge/status-stable-green.svg)](docs/stability.md)
 
 > **LTS — in force.** 1.x is the long-term-support line: through 2027-11-15 active and 2028-05-15 security. See [`docs/lts.md`](./docs/lts.md) for support windows, deprecation policy, and security-backport SLAs.

--- a/crates/llmc/src/codegen.rs
+++ b/crates/llmc/src/codegen.rs
@@ -113,6 +113,17 @@ impl Emitter {
             fe.next_local += 1;
         }
 
+        // Emit `requires` preconditions as runtime guards (Theme A-lite).
+        // Each is evaluated against the arguments at entry; a violation
+        // traps with a ContractViolation carrying the offending args as a
+        // replayable counterexample. `Op::Assert` is emitted only here.
+        for (i, req) in f.requires.iter().enumerate() {
+            self.emit_expr(req, &mut fe)?;
+            let msg = format!("precondition {} failed in `{}`", i + 1, f.name);
+            let msg_idx = self.module.add_const(Value::String(msg));
+            fe.code.push(Op::Assert(msg_idx));
+        }
+
         // Emit body
         self.emit_block(&f.body, &mut fe)?;
 

--- a/crates/llmc/src/tests.rs
+++ b/crates/llmc/src/tests.rs
@@ -201,6 +201,53 @@ mod tests {
     }
 
     #[test]
+    fn test_requires_emits_assert_opcode() {
+        use boruna_bytecode::Op;
+        let module = compile("m", "fn main() -> Int requires true { 0 }").unwrap();
+        let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+        assert!(
+            main.code.iter().any(|op| matches!(op, Op::Assert(_))),
+            "expected an Assert opcode from the requires clause"
+        );
+    }
+
+    #[test]
+    fn test_no_requires_emits_no_assert() {
+        use boruna_bytecode::Op;
+        let module = compile("m", "fn main() -> Int { 0 }").unwrap();
+        let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+        assert!(
+            !main.code.iter().any(|op| matches!(op, Op::Assert(_))),
+            "a function without a contract must not emit Assert"
+        );
+    }
+
+    #[test]
+    fn test_requires_violation_produces_counterexample() {
+        use boruna_vm::VmError;
+        let src = "fn check(x: Int) -> Int requires x > 0 { x }\nfn main() -> Int { check(0) }";
+        let module = compile("test", src).expect("compile");
+        let gateway = CapabilityGateway::new(Policy::allow_all());
+        let mut vm = Vm::new(module, gateway);
+        match vm.run() {
+            Err(VmError::ContractViolation {
+                message,
+                counterexample,
+            }) => {
+                assert!(message.contains("precondition"), "message: {message}");
+                assert_eq!(counterexample, vec!["0".to_string()]);
+            }
+            other => panic!("expected ContractViolation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_requires_satisfied_runs_normally() {
+        let src = "fn check(x: Int) -> Int requires x > 0 { x }\nfn main() -> Int { check(7) }";
+        assert_eq!(run_source(src), boruna_bytecode::Value::Int(7));
+    }
+
+    #[test]
     fn test_parse_type_def() {
         let tokens = lexer::lex("type User { name: String, age: Int }").unwrap();
         let program = parser::parse(tokens).unwrap();

--- a/crates/llmvm/src/error.rs
+++ b/crates/llmvm/src/error.rs
@@ -45,6 +45,16 @@ pub enum VmError {
     #[error("assertion failed: {0}")]
     AssertionFailed(String),
 
+    /// A declared `requires`/`ensures` contract was violated at runtime.
+    /// `counterexample` is the concrete argument list that triggered the
+    /// violation (positional, rendered) — the replayable input an auditor
+    /// needs (borrowed from Vow: counterexample = concrete failing input).
+    #[error("{message} [counterexample: ({})]", counterexample.join(", "))]
+    ContractViolation {
+        message: String,
+        counterexample: Vec<String>,
+    },
+
     #[error("list index out of bounds: index {index}, length {length}")]
     IndexOutOfBounds { index: i64, length: usize },
 

--- a/crates/llmvm/src/vm.rs
+++ b/crates/llmvm/src/vm.rs
@@ -572,8 +572,27 @@ impl Vm {
                             .constants
                             .get(err_const as usize)
                             .map(|v| format!("{v}"))
-                            .unwrap_or_else(|| "assertion failed".into());
-                        return Err(VmError::AssertionFailed(msg));
+                            .unwrap_or_else(|| "contract violation".into());
+                        // Capture the offending arguments (locals[0..arity])
+                        // as a concrete, replayable counterexample. `Op::Assert`
+                        // is emitted only by codegen for `requires`/`ensures`
+                        // contracts, so this is always a contract site.
+                        let arity = self.module.functions[func_idx as usize].arity as usize;
+                        let counterexample: Vec<String> = self
+                            .call_stack
+                            .last()
+                            .map(|f| {
+                                f.locals
+                                    .iter()
+                                    .take(arity)
+                                    .map(|v| format!("{v}"))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        return Err(VmError::ContractViolation {
+                            message: msg,
+                            counterexample,
+                        });
                     }
                 }
                 Op::CapCall(cap_id, arg_count) => {

--- a/docs/design-contracts-runtime.md
+++ b/docs/design-contracts-runtime.md
@@ -1,0 +1,48 @@
+# Design — Runtime-checked contracts + counterexample evidence (Theme A-lite, Sprint 2)
+
+Branch (create AFTER v1.6.0 merges): `feat/contracts-runtime` off updated master.
+Borrowed from Vera/Aver (contracts) + **Vow** (counterexample = concrete replayable input + structured blame). NO SMT/Z3 — aligns with the recorded 1.5.0 "Decided" ruling against symbolic model checking; stays in Boruna's concrete-trace + replay philosophy. User chose this over full-Z3.
+
+## Grounding (verified)
+- `FnDef.requires: Vec<Expr>`, `FnDef.ensures: Vec<Expr>` already parsed, currently UNUSED (dead fields).
+- `Op::Assert(err_const)` exists in bytecode + VM: pops value, if falsy → `VmError::AssertionFailed(msg=const)`. **Never emitted by codegen; no `assert` builtin.** → free to repurpose exclusively for contracts.
+- codegen `emit_function`: registers params as locals 0..n, emits body, appends implicit `Ret`.
+- VM frame has locals; current function arity is `module.functions[idx].arity` → args = locals[0..arity].
+
+## MVP scope (Sprint 2)
+`requires` preconditions → runtime guards with a concrete counterexample captured into evidence.
+`ensures` (needs `result` binding + injection at every return point) → deferred to Sprint 2b, documented.
+
+## Design
+1. **codegen**: in `emit_function`, after params registered and BEFORE body, for each `requires` expr `e_i`:
+   emit code for `e_i` (pushes bool) → `Op::Assert(const_i)` where `const_i` is a String constant
+   `"precondition failed in <fn>"` (or numbered). Reuses the dormant Assert path.
+2. **VM**: replace the `AssertionFailed` outcome of `Op::Assert` with a richer
+   `VmError::ContractViolation { message, counterexample }` where `counterexample` = the current
+   frame's args (`locals[0..arity]`) rendered as `Vec<String>` (positional — no param names needed
+   in bytecode). Structured blame: `requires` violation ⇒ caller-fault (message says so).
+   (Assert is contract-only, so changing its error shape is safe.)
+3. **orchestrator**: when a workflow step fails with a ContractViolation, capture
+   `{step_id, message, counterexample}` into the evidence bundle as `contract_violations.json`
+   (via a new `EvidenceBundleBuilder::add_contract_violations`, same write_file → checksummed →
+   hash-covered → verify pattern as Sprint 1's intents.json). The offending inputs become a
+   replayable, tamper-evident audit record.
+
+## Determinism
+Contract checks are pure boolean evals over args → deterministic. A violation is a deterministic
+function of the inputs; the counterexample IS the replay input (Vow). Replay-verified (feeds the
+evidence bundle). No new nondeterminism.
+
+## Bytecode version
+No NEW opcode (reusing Assert) → no bytecode bump needed. If ensures (2b) needs a `result`-dup
+opcode, that would be the 1.1→1.2 additive bump.
+
+## Tests
+- parse+codegen: `fn f(x: Int) -> Int requires x > 0 { x }` emits Assert at entry.
+- VM: calling with x=-1 → ContractViolation, counterexample ["-1"]; x=5 → ok.
+- evidence: a workflow step whose precondition fails records contract_violations.json, bundle verifies, tamper breaks verify.
+- backward-compat: functions without requires emit no Assert (unchanged bytecode).
+
+## Acceptance
+requires preconditions enforced at runtime; violation yields a concrete counterexample in a
+tamper-evident evidence component; gates green (test/clippy-1.97/fmt).

--- a/docs/reference/ax-language.md
+++ b/docs/reference/ax-language.md
@@ -91,6 +91,28 @@ did. It is covered by the bundle checksums, so tampering with a captured intent 
 `boruna evidence verify` fail. A function may declare at most one `intent`; a second
 is a compile error.
 
+## Contracts (`requires`)
+
+A function may declare one or more `requires <expr>` preconditions, checked at
+runtime against its arguments on entry:
+
+```ax
+fn transfer(amount: Int) -> Int !{db.write} requires amount > 0 {
+    // runs only if amount > 0
+}
+```
+
+If a precondition is false when the function is called, execution traps with a
+contract violation carrying a **counterexample** — the concrete arguments that
+triggered it (e.g. `[0]`) — so the failing input is reproducible. In a workflow,
+the violation surfaces with the stable `error_kind` `contract_violation` and the
+counterexample is recorded in the run's hash-chained audit log (tamper-evident
+evidence). A violation is deterministic in the inputs, so it is not retry-eligible.
+
+Contracts are enforced purely at runtime (concrete-trace checking) — Boruna does
+not use SMT/symbolic proving. `ensures` postconditions are parsed but not yet
+enforced.
+
 ## Records
 
 Define named record types:

--- a/orchestrator/src/workflow/runner.rs
+++ b/orchestrator/src/workflow/runner.rs
@@ -3231,6 +3231,12 @@ pub mod error_class {
     /// exhaustion, stack errors, bytecode errors.
     /// Recommended for retry: no — usually deterministic.
     pub const RUNTIME_ERROR: &str = "runtime_error";
+    /// A declared `requires`/`ensures` contract was violated
+    /// (`VmError::ContractViolation`). The error carries a concrete
+    /// counterexample (the offending arguments).
+    /// Recommended for retry: no — a contract violation is a
+    /// deterministic function of the inputs.
+    pub const CONTRACT_VIOLATION: &str = "contract_violation";
     /// IO error reading the step's source file.
     /// Recommended for retry: maybe — transient FS issues do happen.
     pub const IO_ERROR: &str = "io_error";
@@ -3265,6 +3271,7 @@ fn classify_vm_error(e: &VmError) -> &'static str {
         VmError::AssertionFailed(msg) if is_transient_network_error(msg) => {
             error_class::TRANSIENT_NETWORK
         }
+        VmError::ContractViolation { .. } => error_class::CONTRACT_VIOLATION,
         // All other VmError variants — including assertion failures,
         // type errors, index-out-of-bounds, division by zero, match
         // exhaustion, stack errors, invalid IP / function / constant /
@@ -6635,6 +6642,20 @@ mod tests {
                     length: 3
                 }),
                 error_class::RUNTIME_ERROR
+            );
+        }
+
+        #[test]
+        fn classify_contract_violation() {
+            // A contract violation gets its own stable, distinct class
+            // (not the runtime_error catch-all) so agents/auditors can
+            // recognise a precondition breach and its counterexample.
+            assert_eq!(
+                classify_vm_error(&VmError::ContractViolation {
+                    message: "precondition 1 failed in `check`".into(),
+                    counterexample: vec!["0".into()],
+                }),
+                error_class::CONTRACT_VIOLATION
             );
         }
 


### PR DESCRIPTION
## Sprint 2 / Theme A-lite — agentlanguages.dev competitive-borrow program

Borrowed from **Vera**/**Aver** (design-by-contract) and **Vow** (counterexample = concrete replayable input). **No SMT/Z3** — consistent with the 1.5.0 `Decided` ruling against symbolic model checking; stays in Boruna's concrete-trace + replay philosophy. (User chose this lighter path over full Z3.)

### What
- `requires <expr>` preconditions compiled to runtime guards at function entry (reusing the previously-dormant `Op::Assert` — no bytecode bump). Functions without contracts emit no guard.
- Violation → `VmError::ContractViolation { message, counterexample }`, where `counterexample` is the offending arguments (positional, rendered) — the replayable input an auditor needs. Captured in the run's hash-chained audit log (tamper-evident).
- Stable `error_kind` `contract_violation` (retry: no — deterministic in inputs).
- `ensures` postconditions deferred (documented).

### Gates (local, clippy 1.97)
compiler ✓ · vm ✓ · orchestrator ✓ (new contract + classify tests) · clippy `--all-targets --features serve` ✓ · fmt ✓.

### Release
1.6.0 → 1.7.0 (CHANGELOG, README badge). See `docs/design-contracts-runtime.md`.