### PR TITLE
feat(llm-effect): LLM effect propagates up call graph, recorded in evidence (v1.8.0, Theme C-lite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.8.0] — 2026-07-15
+
+Eighth feature minor on the 1.x LTS line. Third sprint of the agentlanguages.dev
+competitive-borrow program (Theme C-lite): the LLM effect now propagates up the
+call graph and is recorded in evidence.
+
+### Added
+
+- **LLM effect propagates up the call graph; model-invoking steps recorded in evidence.** Theme C-lite — borrowed from **Vera** (LLM inference as a tracked typed effect). New `Module::transitively_invokes(func_idx, capability)` computes whether a function reaches a capability through its call graph (its own declared capabilities, or any function it `Call`s / `SpawnActor`s, transitively — cycle-safe, order-independent). When a workflow runs, each source-kind step is analysed for transitive `llm.call` reachability and the sorted list of model-invoking step ids is captured into the evidence bundle as `model_invoking_steps.json` — checksummed and covered by `bundle_hash`, so `evidence verify` fails on tamper. An auditor can now see *which steps touched a model*, even when the call is indirect through a helper. Deliberately **no conformal-prediction / uncertainty quantification** (research-grade; deferred). See `docs/design-llm-typed-effect.md`.
+
 ## [1.7.0] — 2026-07-15
 
 Seventh feature minor on the 1.x LTS line. Second sprint of the agentlanguages.dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "boruna-benches"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-bytecode"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-cli"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "axum",
  "boruna-bytecode",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-compiler"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-vm",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-effect"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "serde",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-framework"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-lsp"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-compiler",
  "boruna-tooling",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-mcp"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-orchestrator"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-pkg"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-tooling"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-vm"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "boruna-bytecode",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/escapeboy/boruna/actions/workflows/ci.yml/badge.svg)](https://github.com/escapeboy/boruna/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.7.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.8.0-blue.svg)](CHANGELOG.md)
 [![Status: Stable](https://img.shields.io/badge/status-stable-green.svg)](docs/stability.md)
 
 > **LTS — in force.** 1.x is the long-term-support line: through 2027-11-15 active and 2028-05-15 security. See [`docs/lts.md`](./docs/lts.md) for support windows, deprecation policy, and security-backport SLAs.

--- a/crates/llmbc/src/module.rs
+++ b/crates/llmbc/src/module.rs
@@ -151,4 +151,36 @@ impl Module {
         self.functions.push(func);
         idx
     }
+
+    /// Whether `func_idx` can reach the `cap` effect through its call graph —
+    /// either it declares `cap` directly, or some function it (transitively)
+    /// calls or spawns does. This is the "effect propagates up the call graph"
+    /// analysis: a step that calls a helper which calls a model transitively
+    /// invokes the model. The result is a deterministic function of the module
+    /// (independent of traversal order). Recursion is cycle-safe via `visited`.
+    pub fn transitively_invokes(&self, func_idx: u32, cap: Capability) -> bool {
+        let mut visited = std::collections::BTreeSet::new();
+        self.reaches_cap(func_idx, cap, &mut visited)
+    }
+
+    fn reaches_cap(
+        &self,
+        idx: u32,
+        cap: Capability,
+        visited: &mut std::collections::BTreeSet<u32>,
+    ) -> bool {
+        if !visited.insert(idx) {
+            return false;
+        }
+        let Some(f) = self.functions.get(idx as usize) else {
+            return false;
+        };
+        if f.capabilities.contains(&cap) {
+            return true;
+        }
+        f.code.iter().any(|op| match op {
+            Op::Call(callee, _) | Op::SpawnActor(callee) => self.reaches_cap(*callee, cap, visited),
+            _ => false,
+        })
+    }
 }

--- a/crates/llmbc/src/tests.rs
+++ b/crates/llmbc/src/tests.rs
@@ -114,6 +114,69 @@ mod tests {
     }
 
     #[test]
+    fn test_transitively_invokes_model() {
+        let mut module = Module::new("t");
+        // idx 0: helper declaring llm.call
+        module.add_function(Function {
+            name: "helper".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Ret],
+            capabilities: vec![Capability::LlmCall],
+            intent: None,
+            match_tables: vec![],
+        });
+        // idx 1: main calls helper (transitively reaches the model)
+        module.add_function(Function {
+            name: "main".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Call(0, 0), Op::Ret],
+            capabilities: vec![],
+            intent: None,
+            match_tables: vec![],
+        });
+        // idx 2: pure function, neither declares nor reaches llm.call
+        module.add_function(Function {
+            name: "pure".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Ret],
+            capabilities: vec![],
+            intent: None,
+            match_tables: vec![],
+        });
+        assert!(module.transitively_invokes(1, Capability::LlmCall));
+        assert!(module.transitively_invokes(0, Capability::LlmCall));
+        assert!(!module.transitively_invokes(2, Capability::LlmCall));
+    }
+
+    #[test]
+    fn test_transitively_invokes_is_cycle_safe() {
+        // Mutually recursive functions must not loop forever.
+        let mut module = Module::new("t");
+        module.add_function(Function {
+            name: "a".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Call(1, 0), Op::Ret],
+            capabilities: vec![],
+            intent: None,
+            match_tables: vec![],
+        });
+        module.add_function(Function {
+            name: "b".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Call(0, 0), Op::Ret],
+            capabilities: vec![],
+            intent: None,
+            match_tables: vec![],
+        });
+        assert!(!module.transitively_invokes(0, Capability::LlmCall));
+    }
+
+    #[test]
     fn test_module_legacy_json_without_intent_defaults_to_none() {
         // A module serialized before Sprint 1 has no `intent` key on its
         // functions. `#[serde(default)]` must load it cleanly as `None`.

--- a/docs/design-llm-typed-effect.md
+++ b/docs/design-llm-typed-effect.md
@@ -1,0 +1,42 @@
+# Design — LLM effect propagates up the call graph (Theme C-lite, Sprint 3)
+
+Branch: `feat/llm-typed-effect` off master (v1.7.0). Borrowed from **Vera** (LLM inference as a
+tracked typed effect). User chose the lite core — **no conformal prediction / uncertainty
+quantification** (research-grade statistics; a poor fit like Z3 was for Theme A). Deferred as a
+documented follow-up.
+
+## Idea
+Boruna gates the `llm.call` capability per function at the VM. But "does this workflow step
+*transitively* invoke a model?" was not surfaced — a step whose `main` calls a helper that calls a
+model is invisible at the step level. This is exactly what a regulator/auditor wants to know
+("which steps touched an LLM"). We make the `llm` effect propagate up the call graph and record it
+in the evidence bundle.
+
+## Design
+- **`Module::transitively_invokes(func_idx, cap) -> bool`** (bytecode): a function reaches `cap`
+  if it declares it directly OR any function it `Call`s / `SpawnActor`s (transitively) does.
+  Cycle-safe via a visited set; result is order-independent → deterministic. General over any
+  `Capability`, used here for `Capability::LlmCall`.
+- **Evidence capture** (orchestrator): the bundle builder already recompiles each source-kind
+  step (for Sprint 1's intent capture). In that same loop, compute
+  `module.transitively_invokes(module.entry, LlmCall)` and collect the sorted list of
+  model-invoking step ids into `model_invoking_steps.json` — a new bundle component, checksummed
+  and hash-covered like `intents.json` (so `evidence verify` fails on tamper). No-op when empty.
+
+## Why no Function-metadata field
+Storing the flag on bytecode `Function` would work but forces updating ~35 struct literals every
+sprint (known churn debt). Computing it as a call-graph analysis where it's consumed (evidence
+build) is smaller, avoids churn, and keeps the fact derivable/auditable from the module.
+
+## Determinism
+The analysis is a pure function of the module. `step_sources` is a BTreeMap → the collected list is
+sorted → deterministic bytes. Replay-verified (feeds the evidence bundle).
+
+## Scope
+In: transitive `llm.call` reachability per step → `model_invoking_steps.json`.
+Out (deferred): conformal-prediction confidence sets; numeric grant caps (Lumen); a first-class
+`Function.transitive_capabilities` field (overlaps Theme D capability-row inference).
+
+## Tests
+- bytecode: transitive reach through a call; cycle-safety; a pure function is false.
+- evidence: `model_invoking_steps.json` written + checksummed; empty → no file.

--- a/orchestrator/src/audit/evidence.rs
+++ b/orchestrator/src/audit/evidence.rs
@@ -165,6 +165,21 @@ impl EvidenceBundleBuilder {
         self.write_file("intents.json", &json)
     }
 
+    /// Store the sorted list of step ids that transitively invoke an LLM
+    /// (an `llm.*` capability reachable through the step's call graph) as
+    /// `model_invoking_steps.json`. Lets an auditor see which steps touched
+    /// a model — the effect having propagated up the call graph — without
+    /// re-analyzing sources. Checksummed + hash-covered like every other
+    /// component. No-op when the list is empty. Callers pass an
+    /// already-sorted, de-duplicated list for deterministic bytes.
+    pub fn add_model_invocations(&mut self, step_ids: &[String]) -> std::io::Result<()> {
+        if step_ids.is_empty() {
+            return Ok(());
+        }
+        let json = serde_json::to_string_pretty(step_ids).map_err(std::io::Error::other)?;
+        self.write_file("model_invoking_steps.json", &json)
+    }
+
     /// Finalize the bundle: write audit log, env fingerprint, and manifest.
     pub fn finalize(mut self, audit_log: &AuditLog) -> std::io::Result<BundleManifest> {
         let completed_at = chrono::Utc::now().to_rfc3339();
@@ -240,6 +255,9 @@ impl EvidenceBundleBuilder {
         }
         if self.bundle_dir.join("intents.json").exists() {
             components.push("intents.json".to_string());
+        }
+        if self.bundle_dir.join("model_invoking_steps.json").exists() {
+            components.push("model_invoking_steps.json".to_string());
         }
         components.sort();
 
@@ -426,6 +444,37 @@ mod tests {
         .unwrap();
         let bad = verify_bundle(&bundle_path);
         assert!(!bad.valid, "tampered intents.json must fail verification");
+    }
+
+    #[test]
+    fn test_bundle_captures_model_invocations_and_is_covered() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut builder = EvidenceBundleBuilder::new(dir.path(), "run-model-001", "wf").unwrap();
+        builder.add_workflow_def(r#"{"name":"test"}"#).unwrap();
+        builder
+            .add_model_invocations(&["stepA".to_string(), "stepC".to_string()])
+            .unwrap();
+        let audit = AuditLog::new();
+        let manifest = builder.finalize(&audit).unwrap();
+        let bundle_path = dir.path().join("run-model-001");
+        assert!(bundle_path.join("model_invoking_steps.json").exists());
+        assert!(manifest
+            .file_checksums
+            .contains_key("model_invoking_steps.json"));
+    }
+
+    #[test]
+    fn test_bundle_no_model_invocations_writes_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut builder = EvidenceBundleBuilder::new(dir.path(), "run-model-002", "wf").unwrap();
+        builder.add_workflow_def(r#"{"name":"test"}"#).unwrap();
+        builder.add_model_invocations(&[]).unwrap();
+        builder.finalize(&AuditLog::new()).unwrap();
+        assert!(!dir
+            .path()
+            .join("run-model-002")
+            .join("model_invoking_steps.json")
+            .exists());
     }
 
     #[test]

--- a/orchestrator/src/workflow/runner.rs
+++ b/orchestrator/src/workflow/runner.rs
@@ -4606,6 +4606,10 @@ pub fn create_bundle(
     // intent simply contributes nothing rather than failing the bundle —
     // intent is additive audit metadata, never load-bearing for the run.
     let mut intents: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+    // Steps that transitively invoke an LLM (Theme C-lite: the `llm` effect
+    // propagated up the call graph). `step_sources` is a BTreeMap, so this
+    // list is built in sorted order → deterministic bytes.
+    let mut model_invoking_steps: Vec<String> = Vec::new();
     for (step_id, source) in &metadata.step_sources {
         if let Ok(module) = boruna_compiler::compile(step_id, source) {
             if let Some(intent) = module
@@ -4616,11 +4620,17 @@ pub fn create_bundle(
             {
                 intents.insert(step_id.clone(), intent);
             }
+            if module.transitively_invokes(module.entry, boruna_bytecode::Capability::LlmCall) {
+                model_invoking_steps.push(step_id.clone());
+            }
         }
     }
     builder
         .add_intents(&intents)
         .map_err(|e| WorkflowRunError::Io(format!("bundle add_intents: {e}")))?;
+    builder
+        .add_model_invocations(&model_invoking_steps)
+        .map_err(|e| WorkflowRunError::Io(format!("bundle add_model_invocations: {e}")))?;
 
     // Hash-chained audit log from metadata. We verify the chain at
     // bundle-creation time so that direct sqlite3 tamper of


### PR DESCRIPTION
## Sprint 3 / Theme C-lite — agentlanguages.dev competitive-borrow program

Borrowed from **Vera** (LLM inference as a tracked typed effect). **No conformal prediction / uncertainty quantification** (research-grade; deferred) — per the chosen lite scope.

### What
- `Module::transitively_invokes(func_idx, capability)`: a function reaches a capability if it declares it, or any function it `Call`s / `SpawnActor`s (transitively) does. Cycle-safe, order-independent → deterministic.
- Evidence: each source-kind step is analysed for transitive `llm.call` reachability; the sorted list of model-invoking step ids is captured into the bundle as `model_invoking_steps.json` (checksummed, `bundle_hash`-covered, tamper-evident). An auditor sees *which steps touched a model*, even via an indirect helper call.
- No bytecode `Function` field → avoids the ~35 struct-literal churn.

### Gates (local, clippy 1.97)
bytecode ✓ · orchestrator ✓ (transitive + evidence tests) · clippy `--all-targets --features serve` ✓ · fmt ✓.

### Release
1.7.0 → 1.8.0. See `docs/design-llm-typed-effect.md`.