### PR TITLE
feat(capability-inference): infer minimal capabilities + flag over-declaration (v1.9.0, Theme D-lite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.9.0] — 2026-07-15
+
+Ninth feature minor on the 1.x LTS line. Fourth and final sprint of the
+agentlanguages.dev competitive-borrow program (Theme D-lite): capability-row
+inference — the compiler now infers each function's minimal capability set and
+flags over-declarations.
+
+### Added
+
+- **Capability-row inference + over-declaration check (`boruna lang caps`).** Theme D-lite — borrowed from **AILANG** (effect-row inference: the compiler computes the minimal capability set and flags over-declaration). New `Module::needed_capabilities(func_idx)` infers the capabilities a function actually needs — those it invokes directly via `CapCall` plus everything its transitive callees need (cycle-safe, deterministic). `Module::over_declared_capabilities(func_idx)` returns the capabilities a function *declares* (`!{...}`) but never (transitively) uses — an over-grant of authority (a least-privilege smell; not a correctness bug, since the VM still gates at runtime). The new `boruna lang caps <file.ax> [--json]` command reports each function's declared vs. inferred-needed capabilities and exits non-zero when any over-declaration is found, so it can gate least-privilege in CI. Deliberately **no information-flow / data-visibility typing** (a large type-system addition; deferred). See `docs/design-capability-inference.md`.
+
 ## [1.8.0] — 2026-07-15
 
 Eighth feature minor on the 1.x LTS line. Third sprint of the agentlanguages.dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "boruna-benches"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-bytecode"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-cli"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "boruna-bytecode",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-compiler"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-vm",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-effect"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "serde",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-framework"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-lsp"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-compiler",
  "boruna-tooling",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-mcp"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-orchestrator"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-pkg"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-tooling"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "boruna-compiler",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "boruna-vm"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "boruna-bytecode",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/escapeboy/boruna/actions/workflows/ci.yml/badge.svg)](https://github.com/escapeboy/boruna/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.8.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.9.0-blue.svg)](CHANGELOG.md)
 [![Status: Stable](https://img.shields.io/badge/status-stable-green.svg)](docs/stability.md)
 
 > **LTS — in force.** 1.x is the long-term-support line: through 2027-11-15 active and 2028-05-15 security. See [`docs/lts.md`](./docs/lts.md) for support windows, deprecation policy, and security-backport SLAs.

--- a/crates/llmbc/src/module.rs
+++ b/crates/llmbc/src/module.rs
@@ -183,4 +183,71 @@ impl Module {
             _ => false,
         })
     }
+
+    /// The *inferred minimal* capability set `func_idx` actually needs: the
+    /// capabilities it invokes directly (via `CapCall`) plus everything its
+    /// transitive callees need. Sorted by capability id, deterministic,
+    /// cycle-safe. Compare against the function's declared `capabilities` to
+    /// find over-grants (see [`Self::over_declared_capabilities`]).
+    pub fn needed_capabilities(&self, func_idx: u32) -> Vec<Capability> {
+        let mut cap_ids = std::collections::BTreeSet::new();
+        let mut visited = std::collections::BTreeSet::new();
+        self.collect_needed(func_idx, &mut cap_ids, &mut visited);
+        cap_ids
+            .into_iter()
+            .filter_map(Capability::from_id)
+            .collect()
+    }
+
+    fn collect_needed(
+        &self,
+        idx: u32,
+        out: &mut std::collections::BTreeSet<u32>,
+        visited: &mut std::collections::BTreeSet<u32>,
+    ) {
+        if !visited.insert(idx) {
+            return;
+        }
+        let Some(f) = self.functions.get(idx as usize) else {
+            return;
+        };
+        for op in &f.code {
+            match op {
+                Op::CapCall(cap_id, _) => {
+                    out.insert(*cap_id);
+                }
+                Op::Call(callee, _) | Op::SpawnActor(callee) => {
+                    self.collect_needed(*callee, out, visited);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Capabilities `func_idx` declares but does not (transitively) need — an
+    /// over-grant of authority (a least-privilege smell, not a correctness
+    /// bug: the VM still gates at runtime). Sorted by capability id,
+    /// deterministic. Empty when the declared set is exactly minimal.
+    pub fn over_declared_capabilities(&self, func_idx: u32) -> Vec<Capability> {
+        let Some(f) = self.functions.get(func_idx as usize) else {
+            return Vec::new();
+        };
+        let needed: std::collections::BTreeSet<u32> = self
+            .needed_capabilities(func_idx)
+            .iter()
+            .map(|c| c.id())
+            .collect();
+        let mut over_ids: Vec<u32> = f
+            .capabilities
+            .iter()
+            .map(|c| c.id())
+            .filter(|id| !needed.contains(id))
+            .collect();
+        over_ids.sort_unstable();
+        over_ids.dedup();
+        over_ids
+            .into_iter()
+            .filter_map(Capability::from_id)
+            .collect()
+    }
 }

--- a/crates/llmbc/src/tests.rs
+++ b/crates/llmbc/src/tests.rs
@@ -177,6 +177,70 @@ mod tests {
     }
 
     #[test]
+    fn test_needed_and_over_declared_capabilities() {
+        let mut module = Module::new("t");
+        // idx 0: worker directly does a NetFetch effect and declares exactly it.
+        module.add_function(Function {
+            name: "worker".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::CapCall(Capability::NetFetch.id(), 0), Op::Ret],
+            capabilities: vec![Capability::NetFetch],
+            intent: None,
+            match_tables: vec![],
+        });
+        // idx 1: `over` only calls worker but declares NetFetch AND FsWrite.
+        // It transitively needs NetFetch (via worker) but never needs FsWrite.
+        module.add_function(Function {
+            name: "over".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Call(0, 0), Op::Ret],
+            capabilities: vec![Capability::NetFetch, Capability::FsWrite],
+            intent: None,
+            match_tables: vec![],
+        });
+        // worker: minimal — no over-grant.
+        assert_eq!(module.needed_capabilities(0), vec![Capability::NetFetch]);
+        assert!(module.over_declared_capabilities(0).is_empty());
+        // over: needs NetFetch transitively; FsWrite is an over-grant.
+        assert_eq!(module.needed_capabilities(1), vec![Capability::NetFetch]);
+        assert_eq!(
+            module.over_declared_capabilities(1),
+            vec![Capability::FsWrite]
+        );
+    }
+
+    #[test]
+    fn test_needed_capabilities_cycle_safe() {
+        let mut module = Module::new("t");
+        module.add_function(Function {
+            name: "a".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![Op::Call(1, 0), Op::Ret],
+            capabilities: vec![],
+            intent: None,
+            match_tables: vec![],
+        });
+        module.add_function(Function {
+            name: "b".into(),
+            arity: 0,
+            locals: 0,
+            code: vec![
+                Op::CapCall(Capability::DbQuery.id(), 0),
+                Op::Call(0, 0),
+                Op::Ret,
+            ],
+            capabilities: vec![Capability::DbQuery],
+            intent: None,
+            match_tables: vec![],
+        });
+        // a → b → a (cycle); a transitively needs DbQuery via b, no infinite loop.
+        assert_eq!(module.needed_capabilities(0), vec![Capability::DbQuery]);
+    }
+
+    #[test]
     fn test_module_legacy_json_without_intent_defaults_to_none() {
         // A module serialized before Sprint 1 has no `intent` key on its
         // functions. `#[serde(default)]` must load it cleanly as `None`.

--- a/crates/llmvm-cli/src/main.rs
+++ b/crates/llmvm-cli/src/main.rs
@@ -625,6 +625,15 @@ enum LangCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Report each function's declared vs. inferred-needed capabilities and
+    /// flag over-declarations (capabilities granted but never used).
+    Caps {
+        /// Source file (.ax)
+        file: PathBuf,
+        /// Output the report as JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2056,6 +2065,82 @@ fn run_lang(cmd: LangCommand) -> Result<(), Box<dyn std::error::Error>> {
                         c.code, c.name, c.category, c.summary
                     );
                 }
+            }
+        }
+        LangCommand::Caps { file, json } => {
+            let source = fs::read_to_string(&file)?;
+            let module = match boruna_compiler::compile(&file.display().to_string(), &source) {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!("compile error: {e}");
+                    process::exit(1);
+                }
+            };
+            let mut any_over = false;
+            // (function, declared, needed, over_declared) — capability names.
+            type CapRow = (
+                String,
+                Vec<&'static str>,
+                Vec<&'static str>,
+                Vec<&'static str>,
+            );
+            let mut report: Vec<CapRow> = Vec::new();
+            for (idx, f) in module.functions.iter().enumerate() {
+                let declared: Vec<&str> = f.capabilities.iter().map(|c| c.name()).collect();
+                let needed: Vec<&str> = module
+                    .needed_capabilities(idx as u32)
+                    .iter()
+                    .map(|c| c.name())
+                    .collect();
+                let over: Vec<&str> = module
+                    .over_declared_capabilities(idx as u32)
+                    .iter()
+                    .map(|c| c.name())
+                    .collect();
+                if !over.is_empty() {
+                    any_over = true;
+                }
+                report.push((f.name.clone(), declared, needed, over));
+            }
+            if json {
+                let functions: Vec<_> = report
+                    .iter()
+                    .map(|(name, declared, needed, over)| {
+                        serde_json::json!({
+                            "function": name,
+                            "declared": declared,
+                            "needed": needed,
+                            "over_declared": over,
+                        })
+                    })
+                    .collect();
+                let payload = serde_json::json!({ "version": 1, "functions": functions });
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                for (name, declared, needed, over) in &report {
+                    println!("fn {name}");
+                    let fmt = |v: &[&str]| {
+                        if v.is_empty() {
+                            "(none)".to_string()
+                        } else {
+                            v.join(", ")
+                        }
+                    };
+                    println!("  declared: {}", fmt(declared));
+                    println!("  needed:   {}", fmt(needed));
+                    if !over.is_empty() {
+                        println!("  over-declared: {}", over.join(", "));
+                    }
+                }
+                println!();
+                if any_over {
+                    println!("over-declared capabilities found (granted but never used)");
+                } else {
+                    println!("all capability declarations are minimal");
+                }
+            }
+            if any_over {
+                process::exit(1);
             }
         }
     }

--- a/docs/design-capability-inference.md
+++ b/docs/design-capability-inference.md
@@ -1,0 +1,45 @@
+# Design — Capability-row inference / over-declaration check (Theme D-lite, Sprint 4)
+
+Branch (create AFTER v1.8.0 merges): `feat/capability-inference` off updated master (has Theme C's
+call-graph analysis to build on). Borrowed from **AILANG** (effect-row inference — compiler computes
+the minimal capability set and flags over-declaration). User chose the lite core — **no
+information-flow / data-visibility typing** (large type-system addition; deferred).
+
+## Idea
+A function's declared `!{...}` capabilities SHOULD equal what it actually needs (least privilege).
+Today nothing checks this: a function can declare `!{net.fetch}` and never use it (over-grant of
+authority — a real least-privilege / audit smell). Compute each function's *needed* capability set
+from its own effect uses + its callees', and flag capabilities it declares but doesn't need.
+
+## Design
+- **`Module::needed_capabilities(func_idx) -> BTreeSet<Capability>`** (bytecode): the set of caps a
+  function actually requires =
+  { caps referenced by its own `CapCall(cap_id, _)` ops }
+  ∪ ⋃ needed_capabilities(callee) for each `Call`/`SpawnActor` callee.
+  Cycle-safe (visited set); deterministic (BTreeSet). Reuses the call-graph traversal shape from
+  Theme C's `reaches_cap`. NOTE: `CapCall` carries `cap_id: u32` → `Capability::from_id`.
+- **Over-declaration = declared \ needed.** A helper `Module::over_declared_capabilities(func_idx)`
+  returns the sorted caps a function declares but does not (transitively) need.
+- **Surface**: a read-only CLI analysis `boruna lang caps <file.ax> [--json]` (or fold into
+  `boruna lang check` as a Warning-severity diagnostic) listing per-function over-declarations.
+  MVP: a dedicated analysis command that returns, per function, {declared, needed, over_declared}.
+  Decide at implementation time based on how `boruna lang check` diagnostics are structured — if
+  cheap, emit a stable Warning code; else a standalone `caps` subcommand.
+
+## Why not enforce (error) or auto-fix
+Over-declaration is a smell, not a correctness bug (the VM still gates at runtime). Report as a
+warning/analysis, not a hard error — avoids breaking existing `.ax` that over-declares. Under-
+declaration is already caught at runtime by the CapabilityGateway; the compiler need not duplicate.
+
+## Determinism
+Pure function of the module; BTreeSet ordering → deterministic output.
+
+## Scope
+In: `needed_capabilities` + `over_declared_capabilities` analysis + a read-only surface.
+Out (deferred): information-flow/data-visibility typing (Plumbing); auto-repair of over-declarations;
+making it a hard compile error.
+
+## Tests
+- needed_capabilities: direct CapCall; transitive via callee; cycle-safe; union across multiple callees.
+- over_declared: declares net.fetch but never uses → flagged; declares exactly what it needs → empty.
+- surface: CLI/diagnostic returns the expected per-function report.


### PR DESCRIPTION
## Sprint 4 (final) / Theme D-lite — agentlanguages.dev competitive-borrow program

Borrowed from **AILANG** (effect-row inference: compiler computes the minimal capability set and flags over-declaration). **No information-flow / data-visibility typing** (large type-system addition; deferred) — per the chosen lite scope.

### What
- `Module::needed_capabilities(func_idx)`: the minimal capabilities a function needs — its own `CapCall` effects plus everything its transitive callees need (cycle-safe, deterministic).
- `Module::over_declared_capabilities(func_idx)`: capabilities a function *declares* but never (transitively) uses — a least-privilege smell (not a correctness bug; the VM still gates at runtime).
- `boruna lang caps <file.ax> [--json]`: per-function declared vs. inferred-needed report; **exits non-zero on any over-declaration** so it can gate least-privilege in CI.

### Gates (local, clippy 1.97)
bytecode ✓ (needed/over-declared + cycle tests) · CLI clippy ✓ · fmt ✓ · `lang caps` verified end-to-end.

### Release
1.8.0 → 1.9.0. **Final theme of the 4-sprint program.** See `docs/design-capability-inference.md`.