### PR TITLE
UI: make Evidence Inspector & Workflow Dashboard legible to non-experts

### DIFF
--- a/crates/llmvm-cli/src/dashboard.rs
+++ b/crates/llmvm-cli/src/dashboard.rs
@@ -323,26 +323,85 @@ fn html_escape(s: &str) -> String {
 
 const PAGE_STYLE: &str = r#"
 <style>
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-       max-width: 1200px; margin: 2rem auto; padding: 0 1rem; color: #222; }
-h1, h2 { font-weight: 600; }
-table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
-th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #eee; }
-th { background: #f7f7f7; font-weight: 600; }
-tr:hover { background: #fafafa; }
+:root { color-scheme: light dark; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+       max-width: 1100px; margin: 0 auto; padding: 0 1rem 2rem; color: #1a1a2e;
+       background: #fff; line-height: 1.5; }
+h1 { font-size: 1.3rem; font-weight: 600; margin: 0.2rem 0 0.4rem; }
+h2 { font-size: 1.05rem; font-weight: 600; margin: 1.6rem 0 0.6rem; }
+.topbar { display: flex; flex-wrap: wrap; gap: 6px 20px; align-items: baseline;
+          padding: 14px 0 10px; margin-bottom: 1rem; border-bottom: 2px solid #1a1a2e; }
+.topbar .brand { font-size: 1.05rem; font-weight: 700; color: #1a1a2e; }
+.topbar nav { display: flex; flex-wrap: wrap; gap: 4px 14px; font-size: 0.9rem; }
+.topbar nav a { padding: 2px 6px; border-radius: 3px; }
+.topbar nav a[aria-current="page"] { background: #eef2ff; color: #1e3a8a; font-weight: 600; }
+p.lead { color: #444; font-size: 0.9rem; max-width: 78ch; margin: 0 0 1rem; }
+.hint { color: #6b7280; font-size: 0.8rem; max-width: 82ch; margin: -0.4rem 0 0.8rem; }
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.9rem; }
+caption { text-align: left; color: #6b7280; font-size: 0.8rem; padding: 0 0 0.6rem; }
+th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #eee; vertical-align: top; }
+th { background: #f7f7f7; font-weight: 600; white-space: nowrap; }
+tr:hover td { background: #fafafa; }
 a { color: #2563eb; text-decoration: none; }
 a:hover { text-decoration: underline; }
-.status-running { color: #2563eb; }
-.status-paused { color: #d97706; }
-.status-completed { color: #16a34a; }
-.status-failed { color: #dc2626; }
+.badge { display: inline-block; padding: 1px 9px; border-radius: 12px;
+         font-size: 0.78rem; font-weight: 600; }
+.status-running { background: #dbeafe; color: #1e40af; }
+.status-paused { background: #fef3c7; color: #92400e; }
+.status-completed { background: #dcfce7; color: #166534; }
+.status-failed { background: #fee2e2; color: #991b1b; }
+.status-pending { background: #f3f4f6; color: #374151; }
 .banner { padding: 0.75rem 1rem; background: #fee; color: #991b1b;
           border: 1px solid #fca5a5; border-radius: 4px; margin-bottom: 1rem; }
 code { background: #f3f4f6; padding: 0.1rem 0.3rem; border-radius: 3px;
-       font-family: ui-monospace, SFMono-Regular, monospace; }
+       font-family: ui-monospace, SFMono-Regular, monospace; overflow-wrap: anywhere; }
 .muted { color: #6b7280; font-size: 0.9rem; }
+footer { margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid #e5e5e5;
+         color: #888; font-size: 0.75rem; }
+@media (prefers-color-scheme: dark) {
+ body { background: #14141f; color: #e5e7eb; }
+ h1, .topbar .brand { color: #e5e7eb; }
+ .topbar { border-color: #3a3a55; }
+ .topbar nav a { color: #93c5fd; }
+ .topbar nav a[aria-current="page"] { background: #26263a; color: #c7d2fe; }
+ p.lead { color: #c9cbd1; }
+ .hint, .muted { color: #9aa0ad; }
+ a { color: #93c5fd; }
+ th { background: #26263a; }
+ th, td { border-color: #2a2a3d; }
+ tr:hover td { background: #242438; }
+ code { background: #26263a; }
+ caption { color: #9aa0ad; }
+ footer { color: #7b7f8c; border-color: #2a2a3d; }
+}
 </style>
 "#;
+
+/// Top navigation bar shared by both dashboard pages. `active` is the
+/// nav key of the current page ("runs" for the list; detail pages are
+/// also under "runs") so the matching link gets an `aria-current` cue.
+fn render_header(active: &str) -> String {
+    let cur = |k: &str| {
+        if k == active {
+            r#" aria-current="page""#
+        } else {
+            ""
+        }
+    };
+    format!(
+        r#"<header class="topbar">
+  <span class="brand">Boruna Workflow Dashboard</span>
+  <nav aria-label="Dashboard sections">
+    <a href="/"{r}>Runs</a>
+    <a href="/api/runs"{j}>JSON API</a>
+  </nav>
+</header>"#,
+        r = cur("runs"),
+        j = cur("api"),
+    )
+}
 
 fn render_banner(bind_warning: Option<&str>) -> String {
     match bind_warning {
@@ -358,7 +417,11 @@ fn render_banner(bind_warning: Option<&str>) -> String {
 fn render_index(runs: &[RunRow], bind_warning: Option<&str>) -> String {
     let banner = render_banner(bind_warning);
     let mut body = String::new();
-    body.push_str("<h1>Boruna runs</h1>");
+    body.push_str("<h1>Workflow runs</h1>");
+    body.push_str(
+        r#"<p class="lead">Every workflow execution recorded in this Boruna instance. Each row is one
+run; click its <strong>Run ID</strong> to see per-step progress, outputs, and errors. Times are UTC.</p>"#,
+    );
     body.push_str(&format!(
         r#"<p class="muted">{} run{} total</p>"#,
         runs.len(),
@@ -366,17 +429,24 @@ fn render_index(runs: &[RunRow], bind_warning: Option<&str>) -> String {
     ));
 
     if runs.is_empty() {
-        body.push_str(r#"<p class="muted">No runs yet. Start one with <code>boruna workflow run ...</code>.</p>"#);
+        body.push_str(r#"<p class="muted">No runs yet. Start one with <code>boruna workflow run ...</code>, then reload this page.</p>"#);
     } else {
-        body.push_str("<table><thead><tr>");
+        body.push_str(r#"<div class="table-wrap"><table>"#);
         body.push_str(
-            "<th>Run ID</th><th>Workflow</th><th>Status</th><th>Started</th><th>Updated</th>",
+            r#"<caption>Status: <span class="badge status-running">running</span>
+            <span class="badge status-paused">paused</span>
+            <span class="badge status-completed">completed</span>
+            <span class="badge status-failed">failed</span></caption>"#,
+        );
+        body.push_str("<thead><tr>");
+        body.push_str(
+            r#"<th scope="col">Run ID</th><th scope="col">Workflow</th><th scope="col">Status</th><th scope="col">Started</th><th scope="col">Updated</th>"#,
         );
         body.push_str("</tr></thead><tbody>");
         for run in runs {
             let status_class = format!("status-{}", run.status.as_str());
             body.push_str(&format!(
-                r#"<tr><td><a href="/runs/{}">{}</a></td><td>{}</td><td class="{}">{}</td><td>{}</td><td>{}</td></tr>"#,
+                r#"<tr><td><a href="/runs/{}"><code>{}</code></a></td><td>{}</td><td><span class="badge {}">{}</span></td><td>{}</td><td>{}</td></tr>"#,
                 html_escape(&run.run_id),
                 html_escape(&run.run_id),
                 html_escape(&run.workflow_name),
@@ -386,12 +456,12 @@ fn render_index(runs: &[RunRow], bind_warning: Option<&str>) -> String {
                 format_ms(run.updated_at_ms),
             ));
         }
-        body.push_str("</tbody></table>");
+        body.push_str("</tbody></table></div>");
     }
 
-    body.push_str(r#"<p class="muted">JSON: <code>GET /api/runs</code></p>"#);
+    body.push_str(r#"<p class="muted">Machine-readable list: <code>GET /api/runs</code></p>"#);
 
-    wrap_page("Boruna runs", &banner, &body)
+    wrap_page("Boruna runs", &render_header("runs"), &banner, &body)
 }
 
 /// Maximum chars of inline output rendered in the HTML detail
@@ -418,47 +488,59 @@ fn render_detail(
     let mut body = String::new();
     body.push_str(r#"<p class="muted"><a href="/">&larr; All runs</a></p>"#);
     body.push_str(&format!("<h1>Run {}</h1>", html_escape(&run.run_id)));
+    body.push_str(
+        r#"<p class="lead">One workflow run. The summary below identifies which workflow ran and its
+current state; the steps table shows each step's progress, retry count, output, and any error.</p>"#,
+    );
 
-    body.push_str("<table>");
+    body.push_str(r#"<div class="table-wrap"><table>"#);
     body.push_str(&format!(
-        "<tr><th>Workflow</th><td>{}</td></tr>",
+        r#"<tr><th scope="row">Workflow</th><td>{}</td></tr>"#,
         html_escape(&run.workflow_name)
     ));
     body.push_str(&format!(
-        "<tr><th>Workflow hash</th><td><code>{}</code></td></tr>",
-        html_escape(&run.workflow_hash)
+        r#"<tr><th scope="row">Workflow hash</th><td><code title="{h}">{h}</code></td></tr>"#,
+        h = html_escape(&run.workflow_hash)
     ));
     if let Some(op) = operational {
         let status_class = format!("status-{}", op.transient_status.as_str());
         body.push_str(&format!(
-            r#"<tr><th>Status</th><td class="{}">{}</td></tr>"#,
+            r#"<tr><th scope="row">Status</th><td><span class="badge {}">{}</span></td></tr>"#,
             status_class,
             op.transient_status.as_str()
         ));
         body.push_str(&format!(
-            "<tr><th>Started</th><td>{}</td></tr>",
+            r#"<tr><th scope="row">Started</th><td>{}</td></tr>"#,
             format_ms(op.started_at_ms)
         ));
         body.push_str(&format!(
-            "<tr><th>Updated</th><td>{}</td></tr>",
+            r#"<tr><th scope="row">Updated</th><td>{}</td></tr>"#,
             format_ms(op.updated_at_ms)
         ));
     }
     if let Some(t) = &run.terminal_status {
         body.push_str(&format!(
-            "<tr><th>Terminal</th><td>{}</td></tr>",
-            t.as_str()
+            r#"<tr><th scope="row">Terminal</th><td><span class="badge status-{c}">{c}</span></td></tr>"#,
+            c = t.as_str()
         ));
     }
-    body.push_str("</table>");
+    body.push_str("</table></div>");
 
     body.push_str(&format!("<h2>Steps ({})</h2>", steps.len()));
     if steps.is_empty() {
-        body.push_str(r#"<p class="muted">No step checkpoints recorded.</p>"#);
-    } else {
-        body.push_str("<table><thead><tr>");
         body.push_str(
-            "<th>Step</th><th>Status</th><th>Attempts</th><th>Started</th><th>Ended</th><th>Output</th><th>Error</th>",
+            r#"<p class="muted">No step checkpoints recorded — the run may not have started
+        any steps yet, or it ran in a mode that does not persist per-step checkpoints.</p>"#,
+        );
+    } else {
+        body.push_str(r#"<div class="table-wrap"><table>"#);
+        body.push_str(
+            r#"<caption>Output shows the recorded JSON result (long values are truncated with … and
+            large ones link out as a blob). Attempts counts retries. Times are UTC.</caption>"#,
+        );
+        body.push_str("<thead><tr>");
+        body.push_str(
+            r#"<th scope="col">Step</th><th scope="col">Status</th><th scope="col">Attempts</th><th scope="col">Started</th><th scope="col">Ended</th><th scope="col">Output</th><th scope="col">Error</th>"#,
         );
         body.push_str("</tr></thead><tbody>");
         for (step, output) in steps.iter().zip(outputs.iter()) {
@@ -472,7 +554,7 @@ fn render_detail(
                 .unwrap_or_default();
             let output_cell = render_output_cell(&run.run_id, output);
             body.push_str(&format!(
-                r#"<tr><td><code>{}</code></td><td class="{}">{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>"#,
+                r#"<tr><td><code>{}</code></td><td><span class="badge {}">{}</span></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>"#,
                 html_escape(&step.step_id),
                 status_class,
                 step.status.as_str(),
@@ -483,15 +565,20 @@ fn render_detail(
                 error,
             ));
         }
-        body.push_str("</tbody></table>");
+        body.push_str("</tbody></table></div>");
     }
 
     body.push_str(&format!(
-        r#"<p class="muted">JSON: <code>GET /api/runs/{}</code></p>"#,
+        r#"<p class="muted">Machine-readable detail: <code>GET /api/runs/{}</code></p>"#,
         html_escape(&run.run_id)
     ));
 
-    wrap_page(&format!("Run {}", run.run_id), &banner, &body)
+    wrap_page(
+        &format!("Run {}", run.run_id),
+        &render_header("runs"),
+        &banner,
+        &body,
+    )
 }
 
 /// Render a single step's Output cell. Sprint 0.5-S7b.
@@ -553,15 +640,20 @@ fn truncate_chars(s: &str, max_chars: usize) -> &str {
     &s[..end]
 }
 
-fn wrap_page(title: &str, banner: &str, body: &str) -> String {
+fn wrap_page(title: &str, header: &str, banner: &str, body: &str) -> String {
     format!(
         r#"<!DOCTYPE html>
 <html lang="en">
-<head><meta charset="utf-8"><title>{}</title>{}</head>
-<body>{}{}</body>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{}</title>{}</head>
+<body>{}{}<main>{}</main>
+<footer>Read-only view over <span class="muted">runs.db</span>. This dashboard cannot start, stop, or
+change runs — manage workflows with the <code>boruna</code> CLI. It ships no authentication; keep it on
+<code>127.0.0.1</code> unless fronted by an auth-enforcing proxy.</footer>
+</body>
 </html>"#,
         html_escape(title),
         PAGE_STYLE,
+        header,
         banner,
         body
     )
@@ -835,7 +927,7 @@ mod tests {
             .unwrap()
             .0;
         // Output column header present.
-        assert!(html.contains("<th>Output</th>"));
+        assert!(html.contains(r#"<th scope="col">Output</th>"#));
         // Inline value rendered (with HTML-escaped quotes).
         assert!(
             html.contains("&quot;hello world&quot;"),

--- a/crates/llmvm-cli/src/evidence_serve.rs
+++ b/crates/llmvm-cli/src/evidence_serve.rs
@@ -96,7 +96,25 @@ pub(crate) fn load_bundle(dir: &Path) -> Result<BundleData, Box<dyn std::error::
 // HTML helpers
 // ---------------------------------------------------------------------------
 
-fn page(title: &str, body: &str) -> String {
+fn page(title: &str, active: &str, body: &str) -> String {
+    // "you are here" cue: mark the matching nav link with aria-current.
+    let cur = |key: &str| {
+        if key == active {
+            r#" aria-current="page""#
+        } else {
+            ""
+        }
+    };
+    let nav = format!(
+        r#"<a href="/bundle"{b}>Overview</a>
+    <a href="/audit"{a}>Audit Log</a>
+    <a href="/outputs"{o}>Outputs</a>
+    <a href="/api/bundle"{j}>JSON API</a>"#,
+        b = cur("bundle"),
+        a = cur("audit"),
+        o = cur("outputs"),
+        j = cur("api"),
+    );
     format!(
         r#"<!DOCTYPE html>
 <html lang="en">
@@ -105,45 +123,74 @@ fn page(title: &str, body: &str) -> String {
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{title} — Boruna Evidence</title>
 <style>
+:root{{color-scheme:light dark}}
 *{{box-sizing:border-box;margin:0;padding:0}}
-body{{font-family:system-ui,sans-serif;background:#f5f5f5;color:#222;line-height:1.5}}
-header{{background:#1a1a2e;color:#fff;padding:12px 24px;display:flex;gap:24px;align-items:center}}
-header h1{{font-size:1.1rem;font-weight:600}}
-nav a{{color:#a0c4ff;text-decoration:none;font-size:.9rem}}
+body{{font-family:system-ui,-apple-system,sans-serif;background:#f5f5f5;color:#1a1a2e;line-height:1.5}}
+a{{color:#2563eb}}
+header{{background:#1a1a2e;color:#fff;padding:12px 24px;display:flex;flex-wrap:wrap;gap:6px 24px;align-items:baseline}}
+header h1{{font-size:1.05rem;font-weight:600}}
+nav{{display:flex;flex-wrap:wrap;gap:4px 14px;font-size:.9rem}}
+nav a{{color:#a0c4ff;text-decoration:none;padding:2px 6px;border-radius:3px}}
 nav a:hover{{text-decoration:underline}}
+nav a[aria-current="page"]{{color:#fff;background:rgba(255,255,255,.15);font-weight:600}}
 main{{max-width:1100px;margin:24px auto;padding:0 16px}}
-h2{{font-size:1.1rem;font-weight:600;margin-bottom:12px;color:#1a1a2e}}
+h2{{font-size:1.05rem;font-weight:600;margin:26px 0 12px;color:#1a1a2e}}
+p.lead{{color:#444;font-size:.9rem;margin-bottom:16px;max-width:74ch}}
+.hint{{color:#666;font-size:.8rem;margin:-2px 0 12px;max-width:82ch}}
 .card{{background:#fff;border:1px solid #ddd;border-radius:6px;padding:20px;margin-bottom:20px}}
-.kv{{display:grid;grid-template-columns:200px 1fr;gap:6px 16px}}
+.kv{{display:grid;grid-template-columns:190px 1fr;gap:8px 16px}}
+@media(max-width:560px){{.kv{{grid-template-columns:1fr}}.kv .k{{margin-top:8px}}}}
 .kv .k{{font-weight:600;color:#555;font-size:.85rem}}
 .kv .v{{font-size:.85rem;word-break:break-all}}
 .badge{{display:inline-block;padding:2px 10px;border-radius:12px;font-size:.8rem;font-weight:600}}
 .pass{{background:#d1fae5;color:#065f46}}
 .fail{{background:#fee2e2;color:#991b1b}}
+.table-wrap{{overflow-x:auto;-webkit-overflow-scrolling:touch}}
 table{{width:100%;border-collapse:collapse;font-size:.85rem}}
-th{{background:#eee;text-align:left;padding:8px 10px;border-bottom:2px solid #ddd}}
+caption{{text-align:left;color:#666;font-size:.8rem;padding:0 0 10px}}
+th{{background:#eee;text-align:left;padding:8px 10px;border-bottom:2px solid #ddd;white-space:nowrap}}
 td{{padding:7px 10px;border-bottom:1px solid #eee;vertical-align:top}}
 tr:hover td{{background:#f9f9f9}}
-.mono{{font-family:monospace;font-size:.8rem}}
+.mono{{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.8rem;overflow-wrap:anywhere}}
 details{{margin-bottom:12px}}
 summary{{cursor:pointer;padding:10px;background:#eef;border:1px solid #ccd;border-radius:4px;font-weight:600;font-size:.9rem}}
 pre{{background:#1e1e1e;color:#d4d4d4;padding:14px;border-radius:4px;overflow:auto;font-size:.8rem;margin-top:8px}}
 .warn{{background:#fffbeb;border:1px solid #f59e0b;padding:12px 16px;border-radius:4px;color:#78350f;font-size:.85rem;margin-bottom:16px}}
+.empty{{color:#666;font-size:.9rem;background:#fafafa;border:1px dashed #ccc;border-radius:6px;padding:16px;max-width:82ch}}
+footer{{max-width:1100px;margin:8px auto 40px;padding:16px;color:#888;font-size:.75rem;border-top:1px solid #e5e5e5}}
+@media (prefers-color-scheme: dark){{
+ body{{background:#14141f;color:#e5e7eb}}
+ a{{color:#93c5fd}}
+ h2{{color:#c7d2fe}}
+ p.lead{{color:#c9cbd1}}
+ .hint{{color:#9aa0ad}}
+ .card{{background:#1e1e2e;border-color:#33334a}}
+ .kv .k{{color:#a9adbb}}
+ th{{background:#26263a;border-color:#33334a}}
+ td{{border-color:#2a2a3d}}
+ tr:hover td{{background:#242438}}
+ summary{{background:#26263a;border-color:#3a3a55;color:#e5e7eb}}
+ caption{{color:#9aa0ad}}
+ .empty{{background:#1b1b28;border-color:#3a3a55;color:#a9adbb}}
+ footer{{color:#7b7f8c;border-color:#2a2a3d}}
+}}
 </style>
 </head>
 <body>
 <header>
   <h1>Boruna Evidence Inspector</h1>
-  <nav>
-    <a href="/bundle">Bundle</a> &nbsp;|&nbsp;
-    <a href="/audit">Audit Log</a> &nbsp;|&nbsp;
-    <a href="/outputs">Outputs</a> &nbsp;|&nbsp;
-    <a href="/api/bundle">JSON API</a>
+  <nav aria-label="Evidence bundle sections">
+    {nav}
   </nav>
 </header>
 <main>
 {body}
 </main>
+<footer>
+  Read-only inspector for one evidence bundle. Runs on <span class="mono">127.0.0.1</span> with no
+  authentication — do not expose it to a network. Verification and export are also available via
+  <span class="mono">boruna evidence verify</span> / <span class="mono">inspect</span>.
+</footer>
 </body>
 </html>"#
     )
@@ -194,35 +241,61 @@ pub(crate) fn render_bundle_page(data: &BundleData) -> String {
         .map(|b| b.format_version.as_str())
         .unwrap_or("(missing bundle.json)"));
 
+    // Explain what VALID / INVALID actually proves — the whole point of the page.
+    let verify_hint = if data.verify_valid {
+        "Every file in this bundle matches the SHA-256 checksum recorded in the manifest, and the \
+         audit log's hash chain is intact. Nothing has been altered since the run was sealed."
+    } else {
+        "One or more checks failed — a file, hash, or audit-chain link does not match what was \
+         sealed at run time. Treat this bundle as untrustworthy until the errors below are resolved."
+    };
+
     let body = format!(
         r#"<h2>Bundle Overview</h2>
+<p class="lead">An <strong>evidence bundle</strong> is a tamper-evident, self-contained record of one
+workflow run: its inputs' hashes, a hash-chained audit log of every step, the recorded outputs, and a
+manifest of SHA-256 checksums that ties it all together. This page verifies that record and shows what
+it contains.</p>
 {errors_html}
 <div class="card">
   <div class="kv">
     <div class="k">verification</div><div class="v">{verify_badge}</div>
-    <div class="k">run_id</div><div class="v mono">{run_id}</div>
+  </div>
+  <p class="hint">{verify_hint}</p>
+  <div class="kv" style="margin-top:12px">
+    <div class="k">run_id</div><div class="v mono" title="{run_id}">{run_id}</div>
     <div class="k">workflow</div><div class="v">{workflow}</div>
     <div class="k">started_at</div><div class="v">{started}</div>
     <div class="k">completed_at</div><div class="v">{completed}</div>
     <div class="k">format_version</div><div class="v">{format_version}</div>
     {enc_row}
   </div>
+  <p class="hint">Look up this same <span class="mono">run_id</span> in the Boruna Workflow
+  Dashboard to see the live run and its per-step status.</p>
 </div>
 <h2>Hashes</h2>
+<p class="hint">Fingerprints that make the bundle tamper-evident. <span class="mono">bundle_hash</span>
+covers the whole bundle; <span class="mono">workflow_hash</span> / <span class="mono">policy_hash</span>
+identify exactly which workflow and policy ran; <span class="mono">audit_log_hash</span> seals the audit
+chain. Re-running the same inputs reproduces the same hashes.</p>
 <div class="card">
   <div class="kv">
-    <div class="k">bundle_hash</div><div class="v mono">{bundle_hash}</div>
-    <div class="k">workflow_hash</div><div class="v mono">{workflow_hash}</div>
-    <div class="k">policy_hash</div><div class="v mono">{policy_hash}</div>
-    <div class="k">audit_log_hash</div><div class="v mono">{audit_hash}</div>
+    <div class="k">bundle_hash</div><div class="v mono" title="{bundle_hash}">{bundle_hash}</div>
+    <div class="k">workflow_hash</div><div class="v mono" title="{workflow_hash}">{workflow_hash}</div>
+    <div class="k">policy_hash</div><div class="v mono" title="{policy_hash}">{policy_hash}</div>
+    <div class="k">audit_log_hash</div><div class="v mono" title="{audit_hash}">{audit_hash}</div>
   </div>
 </div>
 <h2>File Checksums ({file_count} files)</h2>
 <div class="card">
+  <div class="table-wrap">
   <table>
-    <tr><th>File</th><th>SHA-256</th></tr>
-    {file_rows}
+    <caption>Each row is a file in the bundle and the SHA-256 it must match. Verification recomputes
+    these; any mismatch flips the bundle to INVALID. Hover a value to read it in full.</caption>
+    <thead><tr><th scope="col">File</th><th scope="col">SHA-256</th></tr></thead>
+    <tbody>{file_rows}</tbody>
   </table>
+  </div>
 </div>"#,
         run_id = esc(&data.manifest.run_id),
         workflow = esc(&data.manifest.workflow_name),
@@ -239,14 +312,14 @@ pub(crate) fn render_bundle_page(data: &BundleData) -> String {
             .iter()
             .map(|(f, h)| {
                 format!(
-                    r#"<tr><td class="mono">{}</td><td class="mono">{}</td></tr>"#,
+                    r#"<tr><td class="mono">{}</td><td class="mono" title="{h}">{h}</td></tr>"#,
                     esc(f),
-                    esc(h)
+                    h = esc(h)
                 )
             })
             .collect::<String>(),
     );
-    page("Bundle", &body)
+    page("Bundle", "bundle", &body)
 }
 
 pub(crate) fn render_audit_page(data: &BundleData) -> String {
@@ -269,17 +342,34 @@ pub(crate) fn render_audit_page(data: &BundleData) -> String {
         })
         .collect();
 
+    let inner = if data.audit_entries.is_empty() {
+        String::from(
+            r#"<div class="card"><p class="empty">This bundle recorded no audit entries. That usually
+means a partial or demo-mode bundle — a fully recorded run logs one entry per lifecycle event
+(workflow started, each step started/completed, policy checks, and workflow completed).</p></div>"#,
+        )
+    } else {
+        format!(
+            r#"<div class="card" style="padding:0">
+  <div class="table-wrap">
+  <table>
+    <caption style="padding:12px 14px 0">Chronological, append-only record of the run. Each entry is
+    hash-linked to the one before it (entry #N embeds the hash of #N-1), so removing or editing any
+    line breaks the chain and fails verification.</caption>
+    <thead><tr><th scope="col">#</th><th scope="col">Step</th><th scope="col">Event</th><th scope="col">Detail</th></tr></thead>
+    <tbody>{rows}</tbody>
+  </table>
+  </div>
+</div>"#
+        )
+    };
+
     let body = format!(
         r#"<h2>Audit Log ({count} entries)</h2>
-<div class="card" style="padding:0;overflow:auto">
-  <table>
-    <tr><th>#</th><th>Step</th><th>Event</th><th>Detail</th></tr>
-    {rows}
-  </table>
-</div>"#,
+{inner}"#,
         count = data.audit_entries.len()
     );
-    page("Audit Log", &body)
+    page("Audit Log", "audit", &body)
 }
 
 fn describe_event(event: &AuditEvent) -> (String, &'static str, String) {
@@ -367,7 +457,11 @@ fn describe_event(event: &AuditEvent) -> (String, &'static str, String) {
 
 pub(crate) fn render_outputs_page(data: &BundleData) -> String {
     let items: String = if data.outputs.is_empty() {
-        String::from("<p style='color:#888'>No outputs found.</p>")
+        String::from(
+            r#"<p class="empty">No outputs found in this bundle. Demo-mode runs and workflows that
+don't record step results show nothing here — the run may still be valid. Click a step below (when
+present) to expand its recorded JSON result.</p>"#,
+        )
     } else {
         data.outputs
             .iter()
@@ -386,10 +480,12 @@ pub(crate) fn render_outputs_page(data: &BundleData) -> String {
 
     let body = format!(
         r#"<h2>Step Outputs ({count} steps)</h2>
+<p class="lead">The exact JSON result each step produced, as it was sealed into the bundle. These are
+the recorded outputs verified by the checksums on the Overview page.</p>
 <div class="card">{items}</div>"#,
         count = data.outputs.len()
     );
-    page("Outputs", &body)
+    page("Outputs", "outputs", &body)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Improves the two read-only `--features serve` web UIs so a non-expert can understand them (feedback: "I understand nothing about this interface"). Read-only, self-contained, XSS-safe — no behavior change.

## Evidence Inspector (`evidence_serve.rs`)
- Lead paragraph defining what an evidence bundle IS; verification hint explaining what VALID/INVALID proves
- Plain-language hash legend; full-value-on-hover (`title`) for long hashes
- `<caption>` / `<th scope>` on tables, horizontal-scroll wrappers
- Helpful empty states (audit / outputs), active-nav `aria-current`, footer stating read-only/no-auth/127.0.0.1 posture, `prefers-color-scheme` dark mode

## Workflow Dashboard (`dashboard.rs`)
- Shared header/nav with active cue; per-page explanatory copy
- Color-coded status badges (running/paused/completed/failed/pending)
- Semantic markup (`<th scope>`, `<caption>`, `<main>`, viewport meta), scrollable tables
- Footer clarifying it cannot mutate runs (CLI-only); dark mode

Constraints honored: all CSS inline (no CDN/network), read-only (no new mutating routes/forms), routes + JSON API shapes unchanged, every dynamic value still through `esc()`. Gated green locally: build + clippy `-D warnings` + fmt + tests (234). 2 files, +262/-74.