### PR TITLE
feat: borrow agent-language ideas — contracts-in-evidence, boruna_symbols, agent corpus, quickfix gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ The server communicates over JSON-RPC stdio. All tools return structured JSON wi
 | `boruna_template_apply` | Apply a template with variable substitution |
 | `boruna_capability_list` | List the frozen 1.0 capability set with `capability_set_hash` |
 | `boruna_policy_validate` | Validate a `Policy` JSON document; returns typed `error_kind` on rejection |
+| `boruna_symbols` | Extract top-level symbols (fns/records/enums) from `.ax` source → exact typed signatures, capabilities, requires/ensures arity |
 
 ## Agent-native CLI surfaces
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Note: directory paths still use original names (crates/llmbc, crates/llmc, etc.)
 - **boruna-framework** (dir: crates/llmfw) — Framework layer enforcing the App protocol (Elm architecture: init/update/view). `AppValidator`, `AppRuntime`, `TestHarness`, `PolicySet`, state machine diffing.
 - **boruna-effect** (dir: crates/llm-effect) — Token-optimized LLM integration: prompt building, context management, caching, normalization, capability gating for LLM calls.
 - **boruna-cli** (dir: crates/llmvm-cli) — CLI binary (`boruna`). Subcommands: compile, run, trace, replay, inspect, ast, framework, lang, trace2tests, template, workflow, evidence.
-- **boruna-mcp** (dir: crates/boruna-mcp) — MCP server binary (`boruna-mcp`). Exposes 12 tools over JSON-RPC stdio for AI coding agents. Built on rmcp v0.16.
+- **boruna-mcp** (dir: crates/boruna-mcp) — MCP server binary (`boruna-mcp`). Exposes 13 tools over JSON-RPC stdio for AI coding agents. Built on rmcp v0.16.
 
 ### Supporting Crates
 
@@ -151,6 +151,7 @@ MCP (Model Context Protocol) server that exposes Boruna's toolchain to AI coding
 | `boruna_template_apply` | Apply a template with variable substitution |
 | `boruna_capability_list` | Report the capability-set identity hash for `.ax` source |
 | `boruna_policy_validate` | Validate a policy definition (strict validator) |
+| `boruna_symbols` | Extract top-level symbols (fns/records/enums) from `.ax` source → exact typed signatures, capabilities, requires/ensures arity |
 
 ### IDE Configuration
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This makes Boruna suited for teams building AI workflows that touch regulated da
 - **33 built-in functions** — string (12), list (7), and map (7) operations plus type conversions and debug builtins (`__builtin_string_*`, `__builtin_list_*`, `__builtin_map_*`, …) available in every `.ax` file without imports
 - **Import resolution** — `import "std-name"` inlines `libs/<name>/src/core.ax` at compile time; all 13 stdlib packages are 1.0-stable
 - **Four formal versioned specifications** — `.ax` language 1.0, bytecode 1.0, evidence bundle format 1.0, workflow DAG schema 1.0 (all under [`docs/spec/`](./docs/spec/))
-- **MCP server** — exposes 12 tools for AI coding agent integration (Claude Code, Cursor, Codex)
+- **MCP server** — exposes 13 tools for AI coding agent integration (Claude Code, Cursor, Codex)
 
 ## What Boruna is not
 

--- a/crates/boruna-mcp/src/server.rs
+++ b/crates/boruna-mcp/src/server.rs
@@ -88,6 +88,12 @@ struct RunLimitsParams {
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
+struct SymbolsParams {
+    /// The .ax source code to extract top-level symbols from
+    source: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
 struct CheckParams {
     /// The .ax source code to check
     source: String,
@@ -193,6 +199,21 @@ impl BorunaMcpServer {
         validate_source(&params.source)?;
         let source = params.source;
         let result = tokio::task::spawn_blocking(move || tools::compile::parse_ast(&source))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(result)]))
+    }
+
+    #[tool(
+        description = "Extract the top-level SYMBOLS (functions, records, enums) from .ax source with their EXACT declared signatures. For each function: parameter names+types, return type, declared capability set (the !{...} annotation), and requires/ensures clause arity. For records: field names+types. For enums: variant names+payload types. Use this to ground on the real .ax API surface (exact typed signatures) instead of guessing — Boruna is a new language with little training data. Returns success=true with a `symbols` array; a parse failure returns success=false, error_kind='parse_error' as a successful tool response."
+    )]
+    async fn boruna_symbols(
+        &self,
+        Parameters(params): Parameters<SymbolsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        validate_source(&params.source)?;
+        let source = params.source;
+        let result = tokio::task::spawn_blocking(move || tools::symbols::extract_symbols(&source))
             .await
             .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?;
         Ok(CallToolResult::success(vec![Content::text(result)]))

--- a/crates/boruna-mcp/src/tools/mod.rs
+++ b/crates/boruna-mcp/src/tools/mod.rs
@@ -4,6 +4,7 @@ pub mod compile;
 pub mod framework;
 pub mod policy;
 pub mod run;
+pub mod symbols;
 pub mod template;
 pub mod workflow;
 
@@ -69,6 +70,20 @@ mod protocol_version_tests {
     fn ast_failure_carries_protocol_version() {
         let out = compile::parse_ast("@@@ not valid");
         assert_protocol_version(&out, "ast failure");
+    }
+
+    // ── symbols ──
+
+    #[test]
+    fn symbols_success_carries_protocol_version() {
+        let out = symbols::extract_symbols("fn main() -> Int { 1 }\n");
+        assert_protocol_version(&out, "symbols success");
+    }
+
+    #[test]
+    fn symbols_parse_failure_carries_protocol_version() {
+        let out = symbols::extract_symbols("@@@ not valid");
+        assert_protocol_version(&out, "symbols parse failure");
     }
 
     // ── run ──

--- a/crates/boruna-mcp/src/tools/symbols.rs
+++ b/crates/boruna-mcp/src/tools/symbols.rs
@@ -1,0 +1,278 @@
+use boruna_compiler::ast::{FnDef, Item, Program, TypeDef, TypeDefKind, TypeExpr};
+use boruna_compiler::CompileError;
+
+use super::TOOL_RESPONSE_PROTOCOL_VERSION;
+
+/// Extract top-level symbols (functions, records, enums) with their exact
+/// declared signatures from `.ax` source.
+///
+/// Grounds LLM agents on real `.ax` APIs instead of hallucinated ones by
+/// surfacing the exact parameter names/types, return type, declared
+/// capability set, and requires/ensures arity for every top-level symbol.
+///
+/// Only lex + parse are needed: parameter, return, and field/variant types
+/// are all syntactic annotations already present in the parsed AST, so no
+/// type-checking pass is required to report exact declared types.
+pub fn extract_symbols(source: &str) -> String {
+    let tokens = match boruna_compiler::lexer::lex(source) {
+        Ok(t) => t,
+        Err(e) => return parse_error_json(&e),
+    };
+
+    let program: Program = match boruna_compiler::parser::parse(tokens) {
+        Ok(p) => p,
+        Err(e) => return parse_error_json(&e),
+    };
+
+    let symbols: Vec<serde_json::Value> = program
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Function(f) => Some(fn_symbol(f)),
+            Item::TypeDef(t) => Some(type_symbol(t)),
+            // Imports and re-exports are not symbol *definitions*.
+            Item::Import(_) | Item::Export(_) => None,
+        })
+        .collect();
+
+    serde_json::json!({
+        "success": true,
+        "protocol_version": TOOL_RESPONSE_PROTOCOL_VERSION,
+        "symbols": symbols,
+    })
+    .to_string()
+}
+
+fn fn_symbol(f: &FnDef) -> serde_json::Value {
+    let params: Vec<serde_json::Value> = f
+        .params
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "name": p.name,
+                "type": render_type(&p.ty),
+            })
+        })
+        .collect();
+
+    let return_type = f
+        .return_type
+        .as_ref()
+        .map(render_type)
+        .unwrap_or_else(|| "Unit".to_string());
+
+    serde_json::json!({
+        "kind": "fn",
+        "name": f.name,
+        "signature": fn_signature(f, &return_type),
+        "params": params,
+        "return_type": return_type,
+        "capabilities": f.capabilities,
+        "requires": f.requires.len(),
+        "ensures": f.ensures.len(),
+        "intent": f.intent,
+        "exported": f.exported,
+    })
+}
+
+fn fn_signature(f: &FnDef, return_type: &str) -> String {
+    let params: Vec<String> = f
+        .params
+        .iter()
+        .map(|p| format!("{}: {}", p.name, render_type(&p.ty)))
+        .collect();
+    let mut sig = format!("fn {}({}) -> {}", f.name, params.join(", "), return_type);
+    if !f.capabilities.is_empty() {
+        sig.push_str(&format!(" !{{{}}}", f.capabilities.join(", ")));
+    }
+    sig
+}
+
+fn type_symbol(t: &TypeDef) -> serde_json::Value {
+    match &t.kind {
+        TypeDefKind::Record(fields) => {
+            let rendered: Vec<serde_json::Value> = fields
+                .iter()
+                .map(|(name, ty)| {
+                    serde_json::json!({
+                        "name": name,
+                        "type": render_type(ty),
+                    })
+                })
+                .collect();
+            let field_sig: Vec<String> = fields
+                .iter()
+                .map(|(name, ty)| format!("{}: {}", name, render_type(ty)))
+                .collect();
+            serde_json::json!({
+                "kind": "record",
+                "name": t.name,
+                "signature": format!("type {} {{ {} }}", t.name, field_sig.join(", ")),
+                "fields": rendered,
+                "capabilities": Vec::<String>::new(),
+                "exported": t.exported,
+            })
+        }
+        TypeDefKind::Enum(variants) => {
+            let rendered: Vec<serde_json::Value> = variants
+                .iter()
+                .map(|(name, payload)| {
+                    serde_json::json!({
+                        "name": name,
+                        "payload": payload.as_ref().map(render_type),
+                    })
+                })
+                .collect();
+            let variant_sig: Vec<String> = variants
+                .iter()
+                .map(|(name, payload)| match payload {
+                    Some(ty) => format!("{}({})", name, render_type(ty)),
+                    None => name.clone(),
+                })
+                .collect();
+            serde_json::json!({
+                "kind": "enum",
+                "name": t.name,
+                "signature": format!("enum {} {{ {} }}", t.name, variant_sig.join(", ")),
+                "variants": rendered,
+                "capabilities": Vec::<String>::new(),
+                "exported": t.exported,
+            })
+        }
+    }
+}
+
+/// Render a `TypeExpr` back to its `.ax` surface syntax.
+fn render_type(ty: &TypeExpr) -> String {
+    match ty {
+        TypeExpr::Named(n) => n.clone(),
+        TypeExpr::Option(inner) => format!("Option<{}>", render_type(inner)),
+        TypeExpr::Result(ok, err) => {
+            format!("Result<{}, {}>", render_type(ok), render_type(err))
+        }
+        TypeExpr::List(inner) => format!("List<{}>", render_type(inner)),
+        TypeExpr::Map(k, v) => format!("Map<{}, {}>", render_type(k), render_type(v)),
+        TypeExpr::Fn(params, ret) => {
+            let ps: Vec<String> = params.iter().map(render_type).collect();
+            format!("({}) -> {}", ps.join(", "), render_type(ret))
+        }
+    }
+}
+
+fn parse_error_json(err: &CompileError) -> String {
+    let (message, line, col) = match err {
+        CompileError::Lexer { line, col, msg } => (msg.clone(), Some(*line), Some(*col)),
+        CompileError::Parse { line, msg } => (msg.clone(), Some(*line), None),
+        // extract_symbols only lexes + parses, so Type/Codegen cannot occur.
+        CompileError::Type(msg) | CompileError::Codegen(msg) => (msg.clone(), None, None),
+    };
+
+    serde_json::json!({
+        "success": false,
+        "protocol_version": TOOL_RESPONSE_PROTOCOL_VERSION,
+        "error_kind": "parse_error",
+        "error": message,
+        "line": line,
+        "col": col,
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn parse(json: &str) -> Value {
+        serde_json::from_str(json).expect("valid JSON")
+    }
+
+    #[test]
+    fn extracts_fn_record_and_enum() {
+        let source = r#"
+type User { name: String, age: Int }
+
+enum Color { Red, Green, Custom(Int) }
+
+fn fetch(url: String, retries: Int) -> Result<String, String> !{net.fetch} {
+    Ok("body")
+}
+
+fn main() -> Int { 0 }
+"#;
+        let out = extract_symbols(source);
+        let v = parse(&out);
+        assert_eq!(v["success"], true);
+        let syms = v["symbols"].as_array().expect("symbols array");
+        assert_eq!(syms.len(), 4);
+
+        // fetch fn
+        let fetch = syms
+            .iter()
+            .find(|s| s["name"] == "fetch")
+            .expect("fetch symbol");
+        assert_eq!(fetch["kind"], "fn");
+        assert_eq!(fetch["return_type"], "Result<String, String>");
+        assert_eq!(fetch["capabilities"], serde_json::json!(["net.fetch"]));
+        assert_eq!(fetch["params"][0]["name"], "url");
+        assert_eq!(fetch["params"][0]["type"], "String");
+        assert_eq!(fetch["params"][1]["name"], "retries");
+        assert_eq!(fetch["params"][1]["type"], "Int");
+        assert_eq!(
+            fetch["signature"],
+            "fn fetch(url: String, retries: Int) -> Result<String, String> !{net.fetch}"
+        );
+
+        // User record
+        let user = syms
+            .iter()
+            .find(|s| s["name"] == "User")
+            .expect("User symbol");
+        assert_eq!(user["kind"], "record");
+        assert_eq!(user["fields"][0]["name"], "name");
+        assert_eq!(user["fields"][0]["type"], "String");
+        assert_eq!(user["fields"][1]["name"], "age");
+        assert_eq!(user["fields"][1]["type"], "Int");
+
+        // Color enum
+        let color = syms
+            .iter()
+            .find(|s| s["name"] == "Color")
+            .expect("Color symbol");
+        assert_eq!(color["kind"], "enum");
+        let variants = color["variants"].as_array().expect("variants");
+        assert_eq!(variants.len(), 3);
+        assert_eq!(variants[0]["name"], "Red");
+        assert!(variants[0]["payload"].is_null());
+        assert_eq!(variants[2]["name"], "Custom");
+        assert_eq!(variants[2]["payload"], "Int");
+    }
+
+    #[test]
+    fn reports_requires_ensures_arity() {
+        let source = r#"
+fn withdraw(amount: Int) -> Int
+    requires amount > 0
+    ensures result >= 0
+{
+    amount
+}
+"#;
+        let out = extract_symbols(source);
+        let v = parse(&out);
+        assert_eq!(v["success"], true);
+        let withdraw = &v["symbols"][0];
+        assert_eq!(withdraw["name"], "withdraw");
+        assert_eq!(withdraw["requires"], 1);
+        assert_eq!(withdraw["ensures"], 1);
+    }
+
+    #[test]
+    fn parse_failure_reports_error_kind() {
+        let out = extract_symbols("@@@ this is not valid .ax");
+        let v = parse(&out);
+        assert_eq!(v["success"], false);
+        assert_eq!(v["error_kind"], "parse_error");
+        assert!(v["error"].is_string());
+    }
+}

--- a/crates/llmbc/src/lib.rs
+++ b/crates/llmbc/src/lib.rs
@@ -10,7 +10,7 @@ pub use capability::{
     CapabilitySetReport, CAPABILITY_REPORT_PROTOCOL_VERSION,
 };
 pub use module::{BytecodeError, Function, Module};
-pub use opcode::Op;
+pub use opcode::{ContractKind, Op};
 pub use value::Value;
 
 /// Frozen bytecode specification version.

--- a/crates/llmbc/src/opcode.rs
+++ b/crates/llmbc/src/opcode.rs
@@ -1,5 +1,24 @@
 use serde::{Deserialize, Serialize};
 
+/// Which contract clause an [`Op::Assert`] guards. Recorded verbatim
+/// (`requires`/`ensures`) into the evidence trail's `ContractCheck`
+/// events, so an auditor can tell preconditions from postconditions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContractKind {
+    Requires,
+    Ensures,
+}
+
+impl ContractKind {
+    /// Stable lowercase label used in the audit trail.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContractKind::Requires => "requires",
+            ContractKind::Ensures => "ensures",
+        }
+    }
+}
+
 /// Bytecode instructions for the Boruna VM.
 /// Stack-based: operands are pushed/popped from the operand stack.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -63,7 +82,18 @@ pub enum Op {
     ReceiveMsg,
 
     /// Pop value, assert it is truthy or abort with error const index.
-    Assert(u32),
+    ///
+    /// Carries contract provenance for the evidence trail: `kind`
+    /// distinguishes a precondition (`requires`) from a postcondition
+    /// (`ensures`), and `index` is the 0-based clause position within
+    /// that list. The VM records a `ContractCheck` event on every
+    /// evaluation (pass or fail) so a sealed run proves each contract
+    /// held. Emitted only by codegen for `requires`/`ensures` clauses.
+    Assert {
+        msg: u32,
+        kind: ContractKind,
+        index: u32,
+    },
 
     /// Capability call: cap_id, arg_count. Args on stack.
     CapCall(u32, u8),
@@ -262,7 +292,7 @@ impl Op {
             Op::SpawnActor(_) => 0x0F,
             Op::SendMsg => 0x10,
             Op::ReceiveMsg => 0x11,
-            Op::Assert(_) => 0x12,
+            Op::Assert { .. } => 0x12,
             Op::CapCall(_, _) => 0x13,
             Op::Add => 0x20,
             Op::Sub => 0x21,

--- a/crates/llmc/src/codegen.rs
+++ b/crates/llmc/src/codegen.rs
@@ -4,7 +4,7 @@ use boruna_bytecode::capability::Capability;
 use boruna_bytecode::module::{
     Function, MatchArm as BcMatchArm, Module, TypeDef as BcTypeDef, TypeKind as BcTypeKind,
 };
-use boruna_bytecode::opcode::Op;
+use boruna_bytecode::opcode::{ContractKind, Op};
 use boruna_bytecode::value::Value;
 
 use crate::ast::*;
@@ -121,7 +121,11 @@ impl Emitter {
             self.emit_expr(req, &mut fe)?;
             let msg = format!("precondition {} failed in `{}`", i + 1, f.name);
             let msg_idx = self.module.add_const(Value::String(msg));
-            fe.code.push(Op::Assert(msg_idx));
+            fe.code.push(Op::Assert {
+                msg: msg_idx,
+                kind: ContractKind::Requires,
+                index: i as u32,
+            });
         }
 
         // Emit body
@@ -150,7 +154,11 @@ impl Emitter {
                 self.emit_expr(ens, &mut fe)?;
                 let msg = format!("postcondition {} failed in `{}`", i + 1, f.name);
                 let msg_idx = self.module.add_const(Value::String(msg));
-                fe.code.push(Op::Assert(msg_idx));
+                fe.code.push(Op::Assert {
+                    msg: msg_idx,
+                    kind: ContractKind::Ensures,
+                    index: i as u32,
+                });
             }
 
             fe.code.push(Op::LoadLocal(result_local));

--- a/crates/llmc/src/tests.rs
+++ b/crates/llmc/src/tests.rs
@@ -206,7 +206,7 @@ mod tests {
         let module = compile("m", "fn main() -> Int requires true { 0 }").unwrap();
         let main = module.functions.iter().find(|f| f.name == "main").unwrap();
         assert!(
-            main.code.iter().any(|op| matches!(op, Op::Assert(_))),
+            main.code.iter().any(|op| matches!(op, Op::Assert { .. })),
             "expected an Assert opcode from the requires clause"
         );
     }
@@ -217,7 +217,7 @@ mod tests {
         let module = compile("m", "fn main() -> Int { 0 }").unwrap();
         let main = module.functions.iter().find(|f| f.name == "main").unwrap();
         assert!(
-            !main.code.iter().any(|op| matches!(op, Op::Assert(_))),
+            !main.code.iter().any(|op| matches!(op, Op::Assert { .. })),
             "a function without a contract must not emit Assert"
         );
     }

--- a/crates/llmvm/src/replay.rs
+++ b/crates/llmvm/src/replay.rs
@@ -1,11 +1,15 @@
-use boruna_bytecode::{Capability, Value};
+use boruna_bytecode::{Capability, ContractKind, Value};
 use serde::{Deserialize, Serialize};
 
 /// Current version of the EventLog format.
-pub const EVENT_LOG_VERSION: u32 = 1;
+///
+/// Bumped to 2 when `Event::ContractCheck` was added. Version-1 logs
+/// simply lack the variant; they deserialize unchanged (the new arm is
+/// additive), so old evidence still verifies.
+pub const EVENT_LOG_VERSION: u32 = 2;
 
 /// Maximum supported version (for forward-compat rejection).
-const MAX_SUPPORTED_VERSION: u32 = 1;
+const MAX_SUPPORTED_VERSION: u32 = 2;
 
 /// A single event in the execution log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,6 +41,18 @@ pub enum Event {
     SchedulerTick {
         round: u64,
         active_actor: u64,
+    },
+    /// A `requires`/`ensures` contract clause was evaluated at a guard
+    /// site. Recorded for BOTH outcomes so a sealed run proves every
+    /// precondition and postcondition held (`passed: true`) — or pins
+    /// exactly which one failed (`passed: false`, immediately before the
+    /// run traps with `VmError::ContractViolation`). `kind` is
+    /// `"requires"`/`"ensures"`; `index` is the 0-based clause position.
+    ContractCheck {
+        function: String,
+        kind: String,
+        index: usize,
+        passed: bool,
     },
 }
 
@@ -117,6 +133,23 @@ impl EventLog {
         self.events.push(Event::SchedulerTick {
             round,
             active_actor,
+        });
+    }
+
+    /// Record that a contract clause was evaluated. Called by the VM at
+    /// every `requires`/`ensures` guard site for both pass and fail.
+    pub fn log_contract_check(
+        &mut self,
+        function: &str,
+        kind: ContractKind,
+        index: usize,
+        passed: bool,
+    ) {
+        self.events.push(Event::ContractCheck {
+            function: function.to_string(),
+            kind: kind.as_str().to_string(),
+            index,
+            passed,
         });
     }
 
@@ -210,7 +243,10 @@ impl ReplayEngine {
     }
 
     /// Verify that ALL events match (not just CapCall).
-    /// Compares CapCall, ActorSpawn, MessageSend, MessageReceive, SchedulerTick.
+    /// Compares CapCall, ActorSpawn, MessageSend, MessageReceive,
+    /// SchedulerTick, and ContractCheck — every event serializes to JSON
+    /// and is compared position-by-position, so contract checks must
+    /// recur identically (same order, same pass/fail) on replay.
     pub fn verify_full(original: &EventLog, replay: &EventLog) -> ReplayResult {
         let orig = original.events();
         let repl = replay.events();

--- a/crates/llmvm/src/tests.rs
+++ b/crates/llmvm/src/tests.rs
@@ -561,7 +561,11 @@ mod tests {
         let module = simple_module(
             vec![
                 Op::PushConst(0), // true
-                Op::Assert(1),
+                Op::Assert {
+                    msg: 1,
+                    kind: ContractKind::Requires,
+                    index: 0,
+                },
                 Op::PushConst(2),
                 Op::Ret,
             ],
@@ -579,7 +583,11 @@ mod tests {
         let module = simple_module(
             vec![
                 Op::PushConst(0), // false
-                Op::Assert(1),
+                Op::Assert {
+                    msg: 1,
+                    kind: ContractKind::Requires,
+                    index: 0,
+                },
                 Op::PushConst(2),
                 Op::Ret,
             ],
@@ -590,6 +598,194 @@ mod tests {
             ],
         );
         assert!(run_module(module).is_err());
+    }
+
+    #[test]
+    fn test_contract_check_passing_requires_recorded() {
+        // A passing `requires` guard must leave a ContractCheck{passed:true}
+        // in the evidence trail — a passing contract is no longer invisible.
+        let module = simple_module(
+            vec![
+                Op::PushConst(0), // true
+                Op::Assert {
+                    msg: 1,
+                    kind: ContractKind::Requires,
+                    index: 0,
+                },
+                Op::PushConst(2),
+                Op::Ret,
+            ],
+            vec![
+                Value::Bool(true),
+                Value::String("precondition 1 failed in `main`".into()),
+                Value::Int(7),
+            ],
+        );
+        let gateway = CapabilityGateway::new(Policy::allow_all());
+        let mut vm = Vm::new(module, gateway);
+        assert_eq!(vm.run().unwrap(), Value::Int(7));
+
+        let contract_events: Vec<_> = vm
+            .event_log()
+            .events()
+            .iter()
+            .filter(|e| matches!(e, Event::ContractCheck { .. }))
+            .collect();
+        assert_eq!(contract_events.len(), 1);
+        match contract_events[0] {
+            Event::ContractCheck {
+                function,
+                kind,
+                index,
+                passed,
+            } => {
+                assert_eq!(function, "main");
+                assert_eq!(kind, "requires");
+                assert_eq!(*index, 0);
+                assert!(*passed);
+            }
+            other => panic!("expected ContractCheck, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_contract_check_failing_requires_recorded_and_traps() {
+        // A failing `requires` guard must record ContractCheck{passed:false}
+        // AND still trap with VmError::ContractViolation.
+        let module = simple_module(
+            vec![
+                Op::PushConst(0), // false
+                Op::Assert {
+                    msg: 1,
+                    kind: ContractKind::Requires,
+                    index: 0,
+                },
+                Op::PushConst(2),
+                Op::Ret,
+            ],
+            vec![
+                Value::Bool(false),
+                Value::String("precondition 1 failed in `main`".into()),
+                Value::Int(7),
+            ],
+        );
+        let gateway = CapabilityGateway::new(Policy::allow_all());
+        let mut vm = Vm::new(module, gateway);
+        let err = vm.run().expect_err("failing precondition must trap");
+        assert!(matches!(err, VmError::ContractViolation { .. }));
+
+        // Even though the run trapped, the failed check is sealed.
+        let contract_events: Vec<_> = vm
+            .event_log()
+            .events()
+            .iter()
+            .filter(|e| matches!(e, Event::ContractCheck { .. }))
+            .collect();
+        assert_eq!(contract_events.len(), 1);
+        match contract_events[0] {
+            Event::ContractCheck { kind, passed, .. } => {
+                assert_eq!(kind, "requires");
+                assert!(!*passed);
+            }
+            other => panic!("expected ContractCheck, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_contract_check_passing_ensures_recorded() {
+        // A passing `ensures` postcondition records kind="ensures".
+        let module = simple_module(
+            vec![
+                Op::PushConst(0), // true
+                Op::Assert {
+                    msg: 1,
+                    kind: ContractKind::Ensures,
+                    index: 0,
+                },
+                Op::PushConst(2),
+                Op::Ret,
+            ],
+            vec![
+                Value::Bool(true),
+                Value::String("postcondition 1 failed in `main`".into()),
+                Value::Int(99),
+            ],
+        );
+        let gateway = CapabilityGateway::new(Policy::allow_all());
+        let mut vm = Vm::new(module, gateway);
+        assert_eq!(vm.run().unwrap(), Value::Int(99));
+
+        let ensures: Vec<_> = vm
+            .event_log()
+            .events()
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::ContractCheck { kind, passed, .. } if kind == "ensures" && *passed
+                )
+            })
+            .collect();
+        assert_eq!(ensures.len(), 1);
+    }
+
+    #[test]
+    fn test_contract_check_replay_determinism() {
+        // A run containing contract events must verify_full-match a
+        // re-run of the identical module.
+        let make_module = || {
+            simple_module(
+                vec![
+                    Op::PushConst(0), // true
+                    Op::Assert {
+                        msg: 1,
+                        kind: ContractKind::Requires,
+                        index: 0,
+                    },
+                    Op::PushConst(2),
+                    Op::Assert {
+                        msg: 1,
+                        kind: ContractKind::Ensures,
+                        index: 0,
+                    },
+                    Op::PushConst(2),
+                    Op::Ret,
+                ],
+                vec![
+                    Value::Bool(true),
+                    Value::String("contract failed in `main`".into()),
+                    Value::Bool(true),
+                ],
+            )
+        };
+
+        let mut vm1 = Vm::new(make_module(), CapabilityGateway::new(Policy::allow_all()));
+        vm1.run().unwrap();
+        let mut vm2 = Vm::new(make_module(), CapabilityGateway::new(Policy::allow_all()));
+        vm2.run().unwrap();
+
+        // Both runs recorded contract events.
+        assert!(vm1
+            .event_log()
+            .events()
+            .iter()
+            .any(|e| matches!(e, Event::ContractCheck { .. })));
+
+        let result = ReplayEngine::verify_full(vm1.event_log(), vm2.event_log());
+        assert!(
+            matches!(result, ReplayResult::Identical),
+            "contract events must replay identically: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_event_log_explicit_v1_still_reads() {
+        // Backward compat: an explicit version-1 log (no ContractCheck)
+        // must still deserialize after the v2 bump.
+        let v1_json = r#"{"version":1,"events":[{"CapCall":{"capability":"time.now","args":[]}}]}"#;
+        let log = EventLog::from_json(v1_json).unwrap();
+        assert_eq!(log.version(), 1);
+        assert_eq!(log.events().len(), 1);
     }
 
     #[test]
@@ -1021,8 +1217,9 @@ mod tests {
     }
 
     #[test]
-    fn test_event_log_v1_format_stability() {
-        // Golden test: lock the JSON format of EventLog v1
+    fn test_event_log_v2_format_stability() {
+        // Golden test: lock the JSON format of the current EventLog
+        // (v2 — bumped when ContractCheck was added).
         let mut log = EventLog::new();
         log.log_cap_call(
             &Capability::NetFetch,
@@ -1033,7 +1230,7 @@ mod tests {
         let json = log.to_json().unwrap();
 
         // Must contain version
-        assert!(json.contains("\"version\": 1"), "must have version: 1");
+        assert!(json.contains("\"version\": 2"), "must have version: 2");
         // Must contain events array
         assert!(json.contains("\"events\""), "must have events array");
         // Must contain CapCall variant

--- a/crates/llmvm/src/vm.rs
+++ b/crates/llmvm/src/vm.rs
@@ -583,9 +583,23 @@ impl Vm {
                         self.push(Value::Unit)?;
                     }
                 }
-                Op::Assert(err_const) => {
+                Op::Assert {
+                    msg: err_const,
+                    kind,
+                    index,
+                } => {
                     let val = self.pop()?;
-                    if !val.is_truthy() {
+                    let passed = val.is_truthy();
+                    // Seal the contract check into the evidence trail for
+                    // BOTH outcomes: a passing run proves the clause held;
+                    // a failing run pins exactly which clause broke, right
+                    // before the trap below. `Op::Assert` is emitted only
+                    // by codegen for contracts, so `func_idx` names the
+                    // function under contract.
+                    let function = self.module.functions[func_idx as usize].name.clone();
+                    self.event_log
+                        .log_contract_check(&function, kind, index as usize, passed);
+                    if !passed {
                         let msg = self
                             .module
                             .constants

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -1,0 +1,38 @@
+# Agent-facing corpus
+
+This directory and a few root-level files exist so an AI coding agent can ingest
+Boruna in a single fetch and then write correct `.ax` without prior training data.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| [`../../llms.txt`](../../llms.txt) | Short, link-first index (the [llms.txt](https://llmstxt.org) convention). Point an agent here first. |
+| [`../../llms-full.txt`](../../llms-full.txt) | The full `.ax` teaching primer inlined into one document: types, records/enums, pattern matching, capabilities, the framework App protocol, and correct snippets. |
+| [`portal.json`](portal.json) | Machine-readable manifest: Boruna version, the 11-capability taxonomy, the 13 stdlib libraries, the 5 templates, and the MCP tool list. |
+
+## How to use it
+
+- **Humans / agents learning the language:** read `llms-full.txt`.
+- **Tools that need structured facts** (capabilities, stdlib, templates, MCP tools):
+  parse `portal.json`.
+- **Deeper reference:** `docs/reference/ax-language.md` (narrative) and
+  `docs/reference/cli.md`. When a snippet is in doubt, verify with
+  `boruna lang check <file>.ax --json`.
+
+## Drift caveat (important)
+
+These files are **static and hand-curated**. They are not yet generated from the
+compiled toolchain, so they can drift from the source of truth:
+
+- The **compiler** (`crates/llmc`) defines the real grammar. Records use the `type`
+  keyword; enum variants are unit or single-payload (`Enum::Variant(payload)`).
+  The narrative reference's `record` keyword and struct-style enum variants are
+  known drift — this corpus follows the compiler.
+- `portal.json` mirrors data that lives in `crates/llmbc` (capabilities), `libs/`
+  (stdlib), `templates/`, and the `boruna-mcp` tool registry.
+
+Per the `"note"` field in `portal.json`, a future `boruna` subcommand should
+**generate** this manifest from the compiled toolchain so it can never drift. Until
+then, update these files whenever capabilities, stdlib packages, templates, MCP
+tools, or language syntax change.

--- a/docs/agent/portal.json
+++ b/docs/agent/portal.json
@@ -1,0 +1,90 @@
+{
+  "note": "static/curated; a future `boruna` subcommand should generate this from the compiled toolchain to prevent drift",
+  "schema_version": 1,
+  "product": "Boruna",
+  "description": "Deterministic execution platform for enterprise AI/LLM-agent workflows. Local engine + CLI only (no server/coordinator/web UI).",
+  "boruna_version": "3.0.0",
+  "language": {
+    "name": "ax",
+    "file_extension": ".ax",
+    "entry_point": "fn main() -> Int",
+    "record_keyword": "type",
+    "enum_variants": "unit or single-payload; construct via Enum::Variant or Enum::Variant(payload)",
+    "immutable": true,
+    "loops": false,
+    "exceptions": false,
+    "primer": "llms-full.txt",
+    "reference": "docs/reference/ax-language.md"
+  },
+  "capabilities": [
+    { "name": "net.fetch", "effect": "HTTP requests to external APIs / webhooks" },
+    { "name": "llm.call", "effect": "LLM inference (hosted or local models)" },
+    { "name": "time.now", "effect": "Read the current timestamp" },
+    { "name": "random", "effect": "Generate random numbers" },
+    { "name": "fs.read", "effect": "Filesystem reads" },
+    { "name": "fs.write", "effect": "Filesystem writes" },
+    { "name": "db.query", "effect": "Database access" },
+    { "name": "ui.render", "effect": "UI surface rendering (framework view output)" },
+    { "name": "actor.spawn", "effect": "Actor creation (parallel agents)" },
+    { "name": "actor.send", "effect": "Inter-actor messaging" },
+    { "name": "step.input", "effect": "Read a workflow step's resolved inputs" }
+  ],
+  "policies": [
+    { "name": "allow-all", "allowed": "all 11 capabilities" },
+    { "name": "deny-all", "allowed": "none (default)" },
+    { "name": "default", "allowed": "none (same as deny-all)" }
+  ],
+  "stdlib": [
+    { "name": "std-ui", "purpose": "Declarative UI primitives for framework apps" },
+    { "name": "std-forms", "purpose": "Model-driven form engine with validation and state tracking" },
+    { "name": "std-authz", "purpose": "Role and permission enforcement via policies" },
+    { "name": "std-http", "purpose": "Safe typed HTTP effect wrappers", "capabilities_required": ["net.fetch"] },
+    { "name": "std-db", "purpose": "Typed database query helpers", "capabilities_required": ["db.query"] },
+    { "name": "std-sync", "purpose": "Offline queue and conflict resolution helpers" },
+    { "name": "std-validation", "purpose": "Reusable composable validation rules" },
+    { "name": "std-routing", "purpose": "Declarative routing model" },
+    { "name": "std-storage", "purpose": "Typed local persistence abstraction" },
+    { "name": "std-notifications", "purpose": "Notification queue and toast helpers" },
+    { "name": "std-testing", "purpose": "High-level test helpers for framework apps" },
+    { "name": "std-llm", "purpose": "Typed LLM effect wrappers for prompting and structured generation", "capabilities_required": ["llm.call"] },
+    { "name": "std-json", "purpose": "JSON-flavoured data extraction and manipulation utilities" }
+  ],
+  "templates": [
+    { "name": "crud-admin", "purpose": "Full CRUD admin panel with authz guards, db effects, form validation" },
+    { "name": "form-basic", "purpose": "Simple validated form with field binding and submission" },
+    { "name": "auth-app", "purpose": "Authentication flow with role management" },
+    { "name": "realtime-feed", "purpose": "Live event feed with polling, rate limiting, and notifications" },
+    { "name": "offline-sync", "purpose": "Offline-first app with sync queue and conflict resolution" }
+  ],
+  "mcp_server": {
+    "binary": "boruna-mcp",
+    "transport": "JSON-RPC over stdio",
+    "tools": [
+      { "name": "boruna_compile", "description": "Compile .ax source -> module info or structured errors" },
+      { "name": "boruna_ast", "description": "Parse .ax source -> AST JSON (truncated at 100KB)" },
+      { "name": "boruna_run", "description": "Compile + execute .ax source with policy/step-limit/trace" },
+      { "name": "boruna_check", "description": "Run diagnostics -> severity, spans, suggested patches" },
+      { "name": "boruna_repair", "description": "Auto-repair .ax source using diagnostic suggestions" },
+      { "name": "boruna_validate_app", "description": "Validate App protocol conformance (init/update/view)" },
+      { "name": "boruna_framework_test", "description": "Run a framework app through a message sequence" },
+      { "name": "boruna_workflow_validate", "description": "Validate workflow DAG structure + topological order" },
+      { "name": "boruna_template_list", "description": "List available app templates" },
+      { "name": "boruna_template_apply", "description": "Apply a template with variable substitution" },
+      { "name": "boruna_capability_list", "description": "Report the capability-set identity hash for .ax source" },
+      { "name": "boruna_policy_validate", "description": "Validate a policy definition (strict validator)" },
+      { "name": "boruna_symbols", "description": "Extract the symbol table (functions, types, capabilities) from .ax source (added this session)" }
+    ]
+  },
+  "resources": {
+    "index": "llms.txt",
+    "primer": "llms-full.txt",
+    "language_reference": "docs/reference/ax-language.md",
+    "cli_reference": "docs/reference/cli.md",
+    "capabilities": "docs/concepts/capabilities.md",
+    "determinism": "docs/concepts/determinism.md",
+    "evidence_bundles": "docs/concepts/evidence-bundles.md",
+    "quickstart": "docs/QUICKSTART.md",
+    "agents_guide": "AGENTS.md",
+    "examples": "examples/"
+  }
+}

--- a/docs/reference/ax-language.md
+++ b/docs/reference/ax-language.md
@@ -28,7 +28,7 @@ fn main() -> Int {
 | `List<T>` | Ordered list | `[1, 2, 3]` |
 | `Map<K, V>` | Key-value map | `{"a": 1, "b": 2}` |
 | Records | Named fields | `Point { x: 1, y: 2 }` |
-| Enums | Tagged union | `Shape::Circle { radius: 5 }` |
+| Enums | Tagged union | `Shape::Circle(5)` |
 
 ## Variables
 
@@ -115,10 +115,10 @@ enforced.
 
 ## Records
 
-Define named record types:
+Define named record types with the `type` keyword:
 
 ```ax
-record Point {
+type Point {
     x: Int,
     y: Int,
 }
@@ -135,21 +135,24 @@ let p2: Point = Point { ..p, y: 10 }
 
 ## Enums
 
+Each variant is either a unit variant or carries a single payload value. Construct a
+value with the `EnumName::Variant(payload)` form (unit variants take no parentheses):
+
 ```ax
 enum Shape {
-    Circle { radius: Float },
-    Rectangle { width: Float, height: Float },
+    Circle(Float),
+    Square(Float),
 }
 
-let s: Shape = Shape::Circle { radius: 5.0 }
+let s: Shape = Shape::Circle(5.0)
 ```
 
 ## Pattern matching
 
 ```ax
 let result: String = match s {
-    Shape::Circle { radius } => "circle"
-    Shape::Rectangle { width, height } => "rectangle"
+    Circle(radius) => "circle"
+    Square(side) => "square"
     _ => "unknown"
 }
 ```
@@ -245,7 +248,7 @@ Point { x: 1, y: 2 }
 Point { ..point, x: 10 }
 
 // Enum variant
-Shape::Circle { radius: 5.0 }
+Shape::Circle(5.0)
 
 // Pattern match
 match x {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,429 @@
+# Boruna `.ax` — Full Language Primer for LLMs
+
+This is a single-document teaching primer for the `.ax` language used by Boruna, a
+deterministic execution platform for enterprise AI/LLM-agent workflows. Read this in
+one pass, then you can write correct `.ax` without prior exposure. Every construct
+below is grounded in the real compiler (`crates/llmc`) and the compiling examples in
+`examples/`. Where the narrative reference (`docs/reference/ax-language.md`) disagrees
+with the compiler, this primer follows the compiler and calls out the difference.
+
+Boruna version: 3.0.0. Boruna is a LOCAL deterministic engine + CLI only (no server,
+no coordinator, no web UI).
+
+--------------------------------------------------------------------------------
+## 1. Mental model
+--------------------------------------------------------------------------------
+
+`.ax` is small, statically typed, and deterministic by construction:
+
+- Variables are immutable. There is no mutation, no loops, and no exceptions.
+- The last expression in a block is its value. There is no `return` keyword.
+- Same input always yields the same output. No ambient randomness, no wall clock.
+- Any side effect (network, LLM, filesystem, DB, time, randomness) must be declared
+  as a **capability** on the function and is gated at runtime by a **policy**.
+- Statements are newline-separated. There are no semicolons.
+- Comments start with `//`.
+
+What `.ax` deliberately does NOT have: mutable variables, loops (use recursion or
+stdlib helpers), exceptions (use `Result<T, E>`), implicit side effects, generics
+(types are concrete at definition sites).
+
+--------------------------------------------------------------------------------
+## 2. File structure & entry point
+--------------------------------------------------------------------------------
+
+Every standalone `.ax` file must define a `main` function. It is the entry point for
+`boruna run`. By convention `main` returns `Int` (used as the exit/result code):
+
+```ax
+fn main() -> Int {
+    42
+}
+```
+
+(Some example files return other types, e.g. `fn main() -> String`, but prefer
+`-> Int` unless you have a reason not to.)
+
+--------------------------------------------------------------------------------
+## 3. Types
+--------------------------------------------------------------------------------
+
+| Type          | Meaning              | Literal examples                 |
+|---------------|----------------------|----------------------------------|
+| `Int`         | 64-bit signed int    | `42`, `-7`                       |
+| `Float`       | 64-bit float         | `3.14`                           |
+| `String`      | UTF-8 string         | `"hello"`                        |
+| `Bool`        | boolean              | `true`, `false`                  |
+| `Unit`        | no value             | `()`                             |
+| `Option<T>`   | optional value       | `Some(42)`, `None`               |
+| `Result<T,E>` | success or error     | `Ok(42)`, `Err("msg")`           |
+| `List<T>`     | ordered list         | `[1, 2, 3]`                      |
+| `Map<K,V>`    | key-value map        | `{ "a": 1, "b": 2 }`             |
+| record types  | named fields         | `Point { x: 1, y: 2 }`           |
+| enum types    | tagged unions        | `Shape::Circle(5.0)`             |
+
+--------------------------------------------------------------------------------
+## 4. Variables
+--------------------------------------------------------------------------------
+
+Immutable bindings with `let` and an explicit type annotation:
+
+```ax
+let name: String = "Boruna"
+let count: Int = 0
+let flag: Bool = true
+let scores: List<Int> = [90, 82, 77]
+let config: Map<String, Int> = { "timeout": 30, "retries": 3 }
+```
+
+No semicolons; one statement per line.
+
+--------------------------------------------------------------------------------
+## 5. Functions
+--------------------------------------------------------------------------------
+
+```ax
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+```
+
+The last expression is the return value. Functions with no capability annotation are
+**pure**: their output depends only on their inputs.
+
+### 5.1 Capability annotations
+
+A function that performs a side effect must declare the required capabilities with a
+`!{...}` clause after the return type:
+
+```ax
+fn fetch(url: String) -> String !{net.fetch} {
+    // live implementation; gated by policy at runtime
+}
+
+fn call_model(prompt: String) -> String !{llm.call} {
+    // live implementation
+}
+
+// multiple capabilities, comma-separated
+fn fetch_and_cache(url: String) -> String !{net.fetch, fs.write} {
+    // live implementation
+}
+```
+
+Without the annotation, the VM rejects any attempt to invoke that capability. The
+11 capabilities are: `net.fetch`, `llm.call`, `time.now`, `random`, `fs.read`,
+`fs.write`, `db.query`, `ui.render`, `actor.spawn`, `actor.send`, `step.input`.
+
+### 5.2 Contracts and intent (optional clauses)
+
+These clauses are optional and order-independent with the capability clause:
+
+```ax
+// precondition, checked at runtime against the arguments on entry
+fn transfer(amount: Int) -> Int !{db.query} requires amount > 0 {
+    amount
+}
+
+// machine-read purpose, captured into the evidence bundle
+fn charge(amount: Int) -> Int !{db.query} intent "Debit customer account" {
+    amount
+}
+```
+
+Notes on fidelity: `requires` preconditions ARE enforced at runtime (a violation
+traps with a reproducible counterexample). `ensures` postconditions are parsed but
+NOT yet enforced. A function may declare at most one `intent`.
+
+--------------------------------------------------------------------------------
+## 6. Records
+--------------------------------------------------------------------------------
+
+Record types are declared with the `type` keyword (this is the keyword the compiler
+actually accepts — the narrative reference's `record` keyword is doc drift):
+
+```ax
+type Point {
+    x: Int,
+    y: Int,
+}
+
+fn main() -> Int {
+    let p: Point = Point { x: 3, y: 4 }
+    let px: Int = p.x
+    px
+}
+```
+
+Field access uses dot notation: `p.x`. Record **spread** creates an updated copy —
+this is how you express a state transition without mutation:
+
+```ax
+type Point {
+    x: Int,
+    y: Int,
+}
+
+fn move_up(p: Point) -> Point {
+    Point { ..p, y: p.y + 1 }
+}
+```
+
+The spread `..p` must come first inside the braces; later fields override.
+
+--------------------------------------------------------------------------------
+## 7. Enums
+--------------------------------------------------------------------------------
+
+Enum variants are either **unit** (no payload) or carry a **single** payload value:
+
+```ax
+enum Action {
+    Increment,
+    Decrement,
+    Reset,
+}
+
+enum Shape {
+    Empty,
+    Circle(Float),
+    Named(String),
+}
+```
+
+Construct a variant with `EnumName::Variant` (unit) or `EnumName::Variant(payload)`:
+
+```ax
+let a: Action = Action::Increment
+let s: Shape = Shape::Circle(5.0)
+```
+
+(The compiler supports a single payload expression per variant. Struct-style enum
+variants like `Circle { radius: Float }` shown in the narrative reference are doc
+drift — use a single payload, or a named record type as the payload.)
+
+--------------------------------------------------------------------------------
+## 8. Pattern matching
+--------------------------------------------------------------------------------
+
+`match` is an expression; every arm returns the same type. Match arms use the bare
+variant name (with an optional binding for the payload), a string literal, or `_`
+as the catch-all. `Option` and `Result` are ordinary enums, so `Some/None/Ok/Err`
+are matched the same way.
+
+Match on an enum:
+
+```ax
+fn describe(s: Shape) -> String {
+    match s {
+        Circle(r) => "circle"
+        Named(name) => name
+        Empty => "empty"
+        _ => "unknown"
+    }
+}
+```
+
+Match on `Option`:
+
+```ax
+fn unwrap_or_zero(value: Option<Int>) -> Int {
+    match value {
+        Some(x) => x
+        None => 0
+    }
+}
+```
+
+Match on `Result`:
+
+```ax
+fn get_or_default(r: Result<Int, String>) -> Int {
+    match r {
+        Ok(v) => v
+        Err(_) => -1
+    }
+}
+```
+
+Match on string literals:
+
+```ax
+fn greet(lang: String) -> String {
+    match lang {
+        "en" => "hello"
+        "es" => "hola"
+        _ => "hi"
+    }
+}
+```
+
+--------------------------------------------------------------------------------
+## 9. Conditionals
+--------------------------------------------------------------------------------
+
+`if`/`else` is an expression. There are no loops; nest `if` or use recursion.
+
+```ax
+fn label(score: Int) -> String {
+    if score > 90 {
+        "pass"
+    } else {
+        "fail"
+    }
+}
+```
+
+--------------------------------------------------------------------------------
+## 10. Built-in functions
+--------------------------------------------------------------------------------
+
+The runtime provides pure built-ins (no import needed). They use a `__builtin_`
+prefix. A representative subset:
+
+- Strings: `__builtin_string_len`, `__builtin_string_contains`,
+  `__builtin_string_to_upper`, `__builtin_string_split`, `__builtin_string_join`,
+  `__builtin_string_slice`, `__builtin_int_parse`.
+- Lists: `__builtin_list_len`, `__builtin_list_head`, `__builtin_list_tail`,
+  `__builtin_list_append`, `__builtin_list_concat`, `__builtin_list_reverse`.
+- Maps: `__builtin_map_get`, `__builtin_map_set`, `__builtin_map_keys`,
+  `__builtin_map_contains_key`, `__builtin_map_len`.
+- Conversions: `__builtin_int_to_string`, `__builtin_float_to_string`,
+  `__builtin_bool_to_string`.
+
+Example:
+
+```ax
+fn main() -> Int {
+    let words: List<String> = ["a", "b", "c"]
+    let n: Int = __builtin_list_len(words)
+    n
+}
+```
+
+--------------------------------------------------------------------------------
+## 11. Imports (standard libraries)
+--------------------------------------------------------------------------------
+
+`import "std-name"` loads a standard library package at compile time; its source is
+inlined before type-checking, and any `fn main` stub in the library is stripped.
+Libraries are resolved from the `libs/` directory relative to the working directory.
+
+```ax
+import "std-json"
+
+fn main() -> Int {
+    let s: String = int_to_string(42)
+    0
+}
+```
+
+The 13 stable stdlib packages: `std-ui`, `std-forms`, `std-authz`, `std-http`,
+`std-db`, `std-sync`, `std-validation`, `std-routing`, `std-storage`,
+`std-notifications`, `std-testing`, `std-llm`, `std-json`. Libraries that need
+capabilities declare them in their manifest (e.g. `std-http` needs `net.fetch`).
+
+--------------------------------------------------------------------------------
+## 12. Framework apps (Elm architecture)
+--------------------------------------------------------------------------------
+
+A framework app defines the protocol types and three functions: `init`, `update`,
+`view`. The protocol types are `State`, `Msg`, `Effect`, `UpdateResult`, `UINode`,
+and (for policy-gated apps) `PolicySet`. `update` must be pure — side effects are
+requested by returning `Effect` values, not performed inline.
+
+This complete example compiles and runs (`boruna framework validate <file>`):
+
+```ax
+// Counter app — the mandatory App protocol: init, update, view
+type State { count: Int }
+type Msg { tag: String, payload: Int }
+type Effect { kind: String, payload: String, callback_tag: String }
+type UpdateResult { state: State, effects: List<Effect> }
+type UINode { tag: String, text: String }
+
+fn init() -> State {
+    State { count: 0 }
+}
+
+fn update(state: State, msg: Msg) -> UpdateResult {
+    let new_count: Int = if msg.tag == "increment" {
+        state.count + 1
+    } else {
+        if msg.tag == "decrement" {
+            state.count - 1
+        } else {
+            if msg.tag == "reset" {
+                0
+            } else {
+                state.count
+            }
+        }
+    }
+    UpdateResult {
+        state: State { count: new_count },
+        effects: [],
+    }
+}
+
+fn view(state: State) -> UINode {
+    UINode { tag: "counter", text: "count" }
+}
+
+fn main() -> Int {
+    let s0: State = init()
+    let m: Msg = Msg { tag: "increment", payload: 0 }
+    let r: UpdateResult = update(s0, m)
+    r.state.count
+}
+```
+
+Test a framework app through a message sequence:
+
+```bash
+boruna framework validate examples/framework/counter_app.ax
+boruna framework test examples/framework/counter_app.ax -m "increment:1,increment:1,reset:0"
+```
+
+--------------------------------------------------------------------------------
+## 13. Running & checking `.ax`
+--------------------------------------------------------------------------------
+
+```bash
+# run a file (deny-all policy by default: no capabilities)
+boruna run examples/hello.ax
+
+# run with all capabilities allowed
+boruna run app.ax --policy allow-all
+
+# static diagnostics (machine-readable)
+boruna lang check app.ax --json
+
+# auto-repair from diagnostic suggestions
+boruna lang repair app.ax
+
+# compile only (no execution)
+boruna compile app.ax
+```
+
+Policies: `allow-all` (all 11 capabilities), `deny-all` (none, the default),
+`default` (same as deny-all). In demo mode (no `--live`) capability calls are
+stubbed; `--live` (requires the `http` feature build) enforces the policy against
+real handlers.
+
+--------------------------------------------------------------------------------
+## 14. Correctness checklist for generated `.ax`
+--------------------------------------------------------------------------------
+
+- Define `fn main() -> Int` in any standalone file.
+- Annotate every `let` with an explicit type.
+- Declare records with `type Name { field: Type, ... }` (NOT `record`).
+- Declare enums with unit or single-payload variants; construct via
+  `Enum::Variant` / `Enum::Variant(payload)`.
+- Match arms are the bare variant name, a string literal, or `_` — not `Enum::Variant`.
+- No loops, no mutation, no `return`, no semicolons.
+- Any side effect needs a `!{capability}` annotation from the 11-capability set.
+- Prefer `Result<T, E>` over any error-throwing idiom; there are no exceptions.
+
+If unsure whether a construct exists, run `boruna lang check <file>.ax --json` or
+consult `docs/reference/ax-language.md` and the compiling files under `examples/`.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,29 @@
+# Boruna
+
+> Boruna is a deterministic execution platform for enterprise AI/LLM-agent workflows, written in Rust. Workflows are DAG-based, policy-gated, and auditable. Each step is written in `.ax` — a small, statically-typed, deterministic language — that compiles to bytecode and runs on a capability-enforcing VM. Every run can emit a hash-chained evidence bundle for compliance. Same input always produces the same output: no ambient randomness, no wall-clock, no hidden side effects. Any effect (network, LLM, filesystem, DB) must be declared as a capability and is gated by a runtime policy.
+
+This file is a curated index for coding agents. For the full inlined language primer (types, syntax, framework protocol, correct `.ax` snippets), read `llms-full.txt` — it is designed to be ingested in one fetch so a model can write correct `.ax` without prior training data.
+
+## Language
+
+- [.ax language reference](docs/reference/ax-language.md): narrative, example-driven syntax and type reference.
+- [.ax teaching primer (full, inlined)](llms-full.txt): the entire language surface in one document, with correct snippets. Start here to write `.ax`.
+- [Capabilities](docs/concepts/capabilities.md): the 11-capability taxonomy and how side effects are declared and gated.
+- [Determinism](docs/concepts/determinism.md): why and how execution is made reproducible.
+
+## CLI & tooling
+
+- [CLI reference](docs/reference/cli.md): every `boruna` command (compile, run, framework, workflow, evidence, lang, template, skills).
+- [MCP server / agent integration](AGENTS.md): the `boruna-mcp` tool surface for AI coding agents.
+- [Agent portal manifest (machine-readable)](docs/agent/portal.json): version, capability taxonomy, stdlib, templates, and MCP tools as JSON.
+
+## Concepts
+
+- [Evidence bundles](docs/concepts/evidence-bundles.md): hash-chained audit logs, replay, and verification.
+- [Quickstart](docs/QUICKSTART.md): 10-minute end-to-end onboarding, ending in `evidence verify`.
+
+## Examples
+
+- [examples/](examples/): runnable `.ax` programs. See `examples/hello.ax`, `examples/pattern_matching.ax`, `examples/counter.ax`.
+- [examples/framework/](examples/framework/): Elm-architecture apps (`counter_app.ax`, `todo_app.ax`).
+- [examples/workflows/](examples/workflows/): DAG workflows (`llm_code_review`, `document_processing`, `customer_support_triage`).

--- a/orchestrator/src/audit/evidence.rs
+++ b/orchestrator/src/audit/evidence.rs
@@ -632,6 +632,81 @@ mod tests {
     }
 
     #[test]
+    fn test_bundle_carries_contract_check_events() {
+        // End-to-end: compile+run an .ax program whose `requires`
+        // precondition passes, capture the VM event log, seal it into an
+        // evidence bundle, verify the bundle, then read the log back and
+        // confirm the ContractCheck event survived into verified evidence.
+        use crate::audit::verify::verify_bundle;
+        use boruna_vm::replay::{Event, EventLog};
+        use boruna_vm::{CapabilityGateway, Policy, Vm};
+
+        let module =
+            boruna_compiler::compile("contract_prog", "fn main() -> Int requires true { 42 }")
+                .expect("program compiles");
+        let mut vm = Vm::new(module, CapabilityGateway::new(Policy::allow_all()));
+        assert_eq!(vm.run().unwrap(), boruna_bytecode::Value::Int(42));
+        let event_log_json = vm.event_log().to_json().unwrap();
+
+        // Sanity: the running VM did record a ContractCheck.
+        assert!(vm
+            .event_log()
+            .events()
+            .iter()
+            .any(|e| matches!(e, Event::ContractCheck { .. })));
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut builder =
+            EvidenceBundleBuilder::new(dir.path(), "run-contract-001", "contract-wf").unwrap();
+        builder.add_workflow_def(r#"{"name":"contract"}"#).unwrap();
+        builder.add_policy(r#"{"default_allow":true}"#).unwrap();
+        builder.add_file("event_log.json", &event_log_json).unwrap();
+
+        let audit = AuditLog::new();
+        let manifest = builder.finalize(&audit).unwrap();
+
+        let bundle_path = dir.path().join("run-contract-001");
+        // The event log is a checksummed, hash-covered component.
+        assert!(manifest.file_checksums.contains_key("event_log.json"));
+
+        // The pristine bundle verifies.
+        let ok = verify_bundle(&bundle_path);
+        assert!(ok.valid, "expected valid bundle, errors: {:?}", ok.errors);
+
+        // Read the sealed log back and confirm the ContractCheck survived.
+        let sealed = std::fs::read_to_string(bundle_path.join("event_log.json")).unwrap();
+        let restored = EventLog::from_json(&sealed).unwrap();
+        let contract = restored
+            .events()
+            .iter()
+            .find(|e| matches!(e, Event::ContractCheck { .. }))
+            .expect("ContractCheck event survived into the bundle");
+        match contract {
+            Event::ContractCheck {
+                function,
+                kind,
+                passed,
+                ..
+            } => {
+                assert_eq!(function, "main");
+                assert_eq!(kind, "requires");
+                assert!(*passed);
+            }
+            other => panic!("expected ContractCheck, got {other:?}"),
+        }
+
+        // Tampering the sealed contract event breaks verification — the
+        // contract trail is inside the hash chain, not decorative.
+        std::fs::write(
+            bundle_path.join("event_log.json"),
+            r#"{"version":2,"events":[]}"#,
+        )
+        .unwrap();
+        let bad = verify_bundle(&bundle_path);
+        assert!(!bad.valid, "tampered event_log.json must fail verification");
+    }
+
+    #[test]
     fn test_bundle_determinism() {
         // Two bundles with same content should have same checksums (except timestamps)
         let dir1 = tempfile::tempdir().unwrap();

--- a/tooling/docs/node-addressed-patches.md
+++ b/tooling/docs/node-addressed-patches.md
@@ -1,0 +1,105 @@
+# Design note: node-addressed repair patches
+
+**Status:** design only — not implemented in this slice.
+**Scope:** `tooling/src/diagnostics` (patch model) + `tooling/src/repair` (applier).
+
+## Current model: text-span patches
+
+A `SuggestedPatch` (`diagnostics/mod.rs`) carries a list of `TextEdit`:
+
+```rust
+pub struct TextEdit {
+    pub file: String,
+    pub start_line: usize,   // 1-based line number
+    pub old_text: String,    // expected current line(s)
+    pub new_text: String,    // replacement
+}
+```
+
+`RepairTool::apply_patch` (`repair/mod.rs`) splits the source into lines, sorts
+edits by `start_line` descending, and for each edit:
+
+1. indexes the line at `start_line - 1`,
+2. verifies `old_text` still matches that line (trim-tolerant),
+3. splices in `new_text`.
+
+Patches are addressed by **absolute line number** plus an `old_text` guard.
+
+## The failure it has: span drift
+
+Line numbers are only valid against the *exact* source the diagnostics were
+collected from. Any edit that inserts or deletes lines above a pending patch
+shifts every later line number, invalidating the address.
+
+Within a single `RepairTool::repair` call this is handled by applying edits
+**bottom-up** (descending `start_line`), so earlier edits never move the target
+of a later one. But that safety does not extend across:
+
+- **Two repair passes.** Collect diagnostics → apply pass 1 (which adds/removes
+  lines, e.g. E005 inserting match arms) → the still-open pass-2 patches now
+  point at stale line numbers. The `old_text` guard turns this into a *skip*
+  (mismatch → `Err`) rather than a corruption, so today's outcome is a silently
+  dropped fix, not a broken file.
+- **Concurrent edits.** An agent edits the file (or a formatter reflows it)
+  between `lang check` and `lang repair`. Same drift, same silent skip.
+- **Multi-line `new_text`.** An edit whose `new_text` changes the line count
+  shifts everything below it; only the descending-sort ordering saves the
+  current single-pass case.
+
+Net effect: repairs are reliable exactly once, against pristine source. The
+agent-repair loop (check → repair → re-check → repair …) is where this bites,
+because pass N+1 runs against source pass N already reflowed.
+
+## What node-addressing changes
+
+Address each edit to an **AST node identity** instead of a line span. The
+compiler already produces a `Program` AST (parsed in `DiagnosticCollector`);
+give every node a stable id (a path such as `item[3].body.stmt[2].expr`, or an
+interned `NodeId` assigned during parse). A patch then says "replace the
+expression at node `N` with this text/subtree", and the applier:
+
+1. re-parses the (possibly already-edited) current source,
+2. locates node `N` by its structural path,
+3. maps the node back to its current byte/line span via the span table,
+4. applies the replacement there.
+
+Because the address is structural, an unrelated insert elsewhere no longer
+moves it — the node is re-located against whatever the source looks like *now*.
+A patch only fails if the targeted node genuinely no longer exists (the thing it
+fixed was already removed), which is the correct outcome.
+
+## Rough effort
+
+Medium — roughly:
+
+- **Parser/AST:** assign stable node ids or a deterministic structural-path
+  scheme + retain per-node spans. The AST already carries line info for
+  diagnostics; this widens it to full spans and an addressing scheme. (largest piece)
+- **Patch model:** add a node-addressed edit variant alongside `TextEdit`
+  (keep both during migration).
+- **Suggest layer:** `suggest.rs` helpers currently compute line numbers +
+  `old_text`; they would instead reference the node they already have in hand
+  (each `enhance_*` / `suggest_*` already walks the AST).
+- **Applier:** re-parse + resolve node → span + splice by byte range, replacing
+  the line-splice logic.
+- **Tests:** the existing `repair/mod.rs` and `analyzer.rs` suites plus the new
+  `quickfix_coverage` gate exercise the behavior; add drift-specific cases
+  (apply pass 1, then pass 2 against reflowed source).
+
+Ballpark: a focused multi-day change, mostly in the compiler AST and the
+applier; the suggest sites are mechanical once node handles are available.
+
+## Migration sketch
+
+1. Add `NodeId`/structural-path + spans to the AST; keep `TextEdit` untouched.
+2. Add `EditTarget::Node { id, new_text }` as an alternative to the current
+   line-addressed edit. `SuggestedPatch.edits` accepts either.
+3. Teach `RepairTool::apply_patch` to resolve node-addressed edits by
+   re-parsing and mapping id → current span; leave the line-addressed path as-is.
+4. Migrate suggest sites one code at a time (E003/E005/E006/E007), each guarded
+   by the `quickfix_coverage` behavioral test, so a regression is caught immediately.
+5. Once all emitters are node-addressed, deprecate the line-addressed variant
+   (or keep it for externally-supplied patches / non-AST files).
+
+No behavior change is forced on consumers until step 4; the two addressing modes
+coexist through the migration.

--- a/tooling/tests/quickfix_coverage.rs
+++ b/tooling/tests/quickfix_coverage.rs
@@ -1,0 +1,210 @@
+//! Quickfix-coverage CI gate.
+//!
+//! Invariant: every stable diagnostic code is *classified* — it is either
+//! auto-fixable (the toolchain emits a `SuggestedPatch` carrying at least one
+//! `TextEdit`, so `boruna lang repair` can apply it mechanically) or it is on an
+//! explicit ALLOWLIST of codes that are intentionally not auto-fixed, each with a
+//! documented reason.
+//!
+//! This turns "some diagnostics have fixes" into an enforced property:
+//!
+//! * The registry (`diagnostics::registry`) is the enumerable source of truth for
+//!   every code the system can emit; a separate drift test in that module keeps it
+//!   1:1 with the `E0NN` constants. So enumerating codes here is complete.
+//! * `FIXABLE` pairs each auto-fixable code with a triggering `.ax` snippet. The
+//!   test drives that snippet through the *real* repair entry point
+//!   (`DiagnosticCollector` → `RepairTool`) and asserts a patch with a real edit
+//!   is produced and applied. This is a behavioral guarantee, not a static claim.
+//! * `ALLOWLIST` names every code that is *not* auto-fixed, with a one-line reason.
+//! * The partition assertion requires `FIXABLE ∪ ALLOWLIST == every registry code`
+//!   with no overlap. Adding a new code to the registry therefore fails this test
+//!   until the author either ships a fixable fixture or allowlists it with a
+//!   reason — forcing the discipline on every future change.
+
+use std::collections::BTreeSet;
+
+use boruna_tooling::diagnostics::collector::DiagnosticCollector;
+use boruna_tooling::diagnostics::registry::registry;
+use boruna_tooling::repair::{RepairStrategy, RepairTool};
+
+/// Codes that ship an auto-applicable quickfix, each paired with source that
+/// triggers the code with a mechanical (non-empty-edit) patch.
+///
+/// Each snippet is run through `DiagnosticCollector::collect()` — the exact path
+/// `boruna lang check`/`repair` uses — so this proves the fix reaches the repair
+/// loop end-to-end, not merely that a helper function exists.
+const FIXABLE: &[(&str, &str)] = &[
+    // E003 undefined-variable → rename to the closest in-scope name.
+    (
+        "E003",
+        "fn main() -> Int {\n    let count = 10\n    countt\n}\n",
+    ),
+    // E005 non-exhaustive-match → insert stub arms for the missing variants.
+    (
+        "E005",
+        "enum Action { Add, Remove, Clear }\n\
+         type State { count: Int }\n\
+         \n\
+         fn update(state: State, action: Action) -> State {\n\
+         \x20   match action {\n\
+         \x20       Add => State { count: state.count + 1 }\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn init() -> State { State { count: 0 } }\n\
+         fn view(state: State) -> String { \"ok\" }\n",
+    ),
+    // E006 unknown-field → rename the field to the closest real field.
+    (
+        "E006",
+        "type State { count: Int, name: String }\n\
+         \n\
+         fn init() -> State {\n\
+         \x20   State { countt: 0, name: \"test\" }\n\
+         }\n",
+    ),
+    // E007 capability-violation → strip the illegal capability annotation.
+    (
+        "E007",
+        "type State { count: Int }\n\
+         type Msg { tag: String }\n\
+         \n\
+         fn init() -> State { State { count: 0 } }\n\
+         fn update(state: State, msg: Msg) -> State !{fs.read} { state }\n\
+         fn view(state: State) -> String { \"ok\" }\n",
+    ),
+];
+
+/// Codes intentionally NOT auto-fixed by the repair loop. Each entry documents
+/// *why* an automatic edit is unsafe or unavailable. A code here must never carry
+/// an applicable quickfix expectation — it requires human judgement.
+const ALLOWLIST: &[(&str, &str)] = &[
+    (
+        "E001",
+        // Lexer: an invalid character/token has no unique correct rewrite.
+        "invalid tokens have no single mechanical repair; the typo must be fixed by a human",
+    ),
+    (
+        "E002",
+        // Parser: malformed syntax is ambiguous (missing brace vs. missing expr).
+        "malformed syntax has no safe mechanical edit; the intended structure is ambiguous",
+    ),
+    (
+        "E004",
+        // Not currently emitted end-to-end: the compiler classifies an undefined
+        // callee as E003 (undefined variable), never E004. The rename repair path
+        // exists (suggest::enhance_undefined_fn, unit-tested in
+        // repair::tests::repair_e004_near_miss_function) but is unreachable until the
+        // compiler distinguishes fn-call errors. Move E004 into FIXABLE when it does.
+        "not emitted by the current compiler (undefined callees surface as E003); \
+         repair path exists but is unreachable end-to-end",
+    ),
+    (
+        "E008",
+        // Codegen: lowering failures reflect unsupported/internal constructs with no
+        // source-level mechanical fix.
+        "codegen/lowering failures have no source-level mechanical fix",
+    ),
+    (
+        "E009",
+        // Type errors only produce a textual conversion hint (empty edits,
+        // Confidence::Low); picking the right coercion needs human intent.
+        "type mismatches yield only a textual hint (no edit); the correct coercion needs human intent",
+    ),
+];
+
+fn registry_codes() -> BTreeSet<String> {
+    registry().iter().map(|c| c.code.to_string()).collect()
+}
+
+fn fixable_codes() -> BTreeSet<String> {
+    FIXABLE.iter().map(|(c, _)| c.to_string()).collect()
+}
+
+fn allowlist_codes() -> BTreeSet<String> {
+    ALLOWLIST.iter().map(|(c, _)| c.to_string()).collect()
+}
+
+/// The gate: every registry code is classified exactly once, as either fixable
+/// or allowlisted. A new code that is neither fails here.
+#[test]
+fn every_diagnostic_code_is_classified() {
+    let all = registry_codes();
+    let fixable = fixable_codes();
+    let allow = allowlist_codes();
+
+    let overlap: Vec<_> = fixable.intersection(&allow).cloned().collect();
+    assert!(
+        overlap.is_empty(),
+        "codes appear in both FIXABLE and ALLOWLIST (must be one or the other): {overlap:?}"
+    );
+
+    let classified: BTreeSet<String> = fixable.union(&allow).cloned().collect();
+
+    let unclassified: Vec<_> = all.difference(&classified).cloned().collect();
+    assert!(
+        unclassified.is_empty(),
+        "diagnostic codes are neither fixable nor allowlisted — ship a quickfix or \
+         add an ALLOWLIST entry with a reason: {unclassified:?}"
+    );
+
+    let stale: Vec<_> = classified.difference(&all).cloned().collect();
+    assert!(
+        stale.is_empty(),
+        "FIXABLE/ALLOWLIST reference codes not in the registry (typo or removed code): {stale:?}"
+    );
+}
+
+/// Every allowlist entry carries a non-empty reason.
+#[test]
+fn allowlist_entries_have_reasons() {
+    for (code, reason) in ALLOWLIST {
+        assert!(
+            !reason.trim().is_empty(),
+            "allowlisted code {code} must document why it is not auto-fixable"
+        );
+    }
+}
+
+/// Behavioral proof: each fixable code, when triggered, actually produces an
+/// applicable quickfix through the real collector → repair path.
+#[test]
+fn fixable_codes_produce_applicable_quickfix() {
+    for (code, source) in FIXABLE {
+        let ds = DiagnosticCollector::new("coverage.ax", source).collect();
+
+        let diag = ds
+            .diagnostics
+            .iter()
+            .find(|d| d.id == *code)
+            .unwrap_or_else(|| {
+                panic!(
+                    "fixture for {code} did not emit that diagnostic; \
+                     emitted: {:?}",
+                    ds.diagnostics.iter().map(|d| &d.id).collect::<Vec<_>>()
+                )
+            });
+
+        let has_applicable_edit = diag
+            .suggested_patches
+            .iter()
+            .any(|p| p.edits.iter().any(|e| !e.new_text.is_empty()));
+        assert!(
+            has_applicable_edit,
+            "{code} is listed FIXABLE but its diagnostic carries no patch with a \
+             non-empty TextEdit — the repair loop cannot act on it"
+        );
+
+        // And the repair tool must actually apply at least one patch.
+        let (repaired, result) =
+            RepairTool::repair("coverage.ax", source, &ds, RepairStrategy::Best, None);
+        assert!(
+            !result.applied.is_empty(),
+            "{code}: RepairTool applied no patch despite an applicable edit being present"
+        );
+        assert_ne!(
+            repaired, *source,
+            "{code}: repaired source is unchanged despite a patch being applied"
+        );
+    }
+}


### PR DESCRIPTION
Borrows the strongest ideas from the other projects catalogued at [agentlanguages.dev](https://agentlanguages.dev), each mapped onto Boruna's determinism + evidence moat. Four disjoint slices, built in parallel and integrated behind full-workspace gates.

## What's in it

### 1. Contract checks → sealed evidence (the differentiator)
`requires`/`ensures` were already enforced as runtime guards, but a *passing* contract left no trace. Now every contract check emits a `ContractCheck { function, kind, index, passed }` event (both pass and fail) into the hash-chained `EventLog`, so an evidence bundle now proves **every precondition/postcondition held on a run** — a compliance artifact none of the verification-camp peers (Vera, Aver) produce.
- New `Event::ContractCheck`; `EVENT_LOG_VERSION` 1→2 (backward-read preserved).
- `Op::Assert` extended to carry `kind` + clause index; VM records both outcomes then still traps on violation.
- End-to-end test: a `ContractCheck` survives into a sealed + `verify_bundle`-passing evidence bundle, and tampering the sealed log fails verification.

### 2. `boruna_symbols` MCP tool (zero-training-data mitigation)
13th MCP tool: `.ax` source → exact typed signatures (fns/records/enums), capabilities, and `requires`/`ensures` arity — so coding agents ground on real APIs instead of hallucinating them.

### 3. Agent-facing corpus (zero-training-data mitigation)
`llms.txt` + `llms-full.txt` (`.ax` teaching primer) + `docs/agent/portal.json` (machine-readable manifest: caps, 13 libs, 5 templates, 13 tools).

### 4. Quickfix-coverage CI gate (X07 discipline)
`tooling/tests/quickfix_coverage.rs` partitions the diagnostic-code registry: every fixable code must ship a repair (proven by a behavioral fixture that emits + applies a real edit) or be allowlisted with a reason. Plus a node-addressed-patch design note.

### 5. Doc-drift fix (surfaced by the work)
`docs/reference/ax-language.md` showed syntax that does not compile (`record` keyword, struct-style enum variants, `Enum::Variant` match paths). Corrected to the real grammar (`type`, single-payload variants, bare match patterns), each form verified with `boruna lang check`.

## Verification
Full-workspace gates on the integrated branch: **`cargo fmt --check` clean · `cargo clippy --workspace -D warnings` zero warnings · `cargo test --workspace` = 1402 passed / 0 failed** (+14 new tests).

## Deferred (need a design pass first)
Behavioral certificates (Lean), conformal-confidence gating, type-guided token sampling, M-EVAL benchmark harness.

https://claude.ai/code/session_01BEk2VHyMr1MrSPitnhox5o
